### PR TITLE
Se ha realizado:

### DIFF
--- a/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
+++ b/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
@@ -37,67 +37,89 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: var(--space-6);
+  gap: var(--space-4);
   max-width: var(--container-2xl);
   margin: 0 auto;
   padding: 0 var(--space-6);
 }
 
+/* ── Card ── */
 .card {
   position: relative;
   overflow: hidden;
-  border-radius: var(--radius-xl);
-  aspect-ratio: 4/3;
+  border-radius: var(--radius-2xl);
+  aspect-ratio: 3/4;
   cursor: pointer;
   text-decoration: none;
   display: block;
+  box-shadow: var(--shadow-lg);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
-/* .card:nth-child(1) {
-  grid-column: span 2;
-} */
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-xl);
+}
 
 .cardImage {
   width: 100%;
   height: 100%;
   object-fit: cover;
   transition: transform var(--transition-slow);
+  filter: brightness(1.05) saturate(1.05);
 }
 
 .card:hover .cardImage {
   transform: scale(1.06);
 }
 
+/* ── Overlay: semitransparente centrado estilo Econo ── */
 .cardOverlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.900) 0%, rgba(0, 0, 0, 0) 80%);
+  background: rgba(0, 0, 0, 0.32);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding: var(--space-6);
-  transition:all 350ms ease-out 0s;;
+  padding: var(--space-5) var(--space-4);
+  transition: background var(--transition-base);
 }
 
 .card:hover .cardOverlay {
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0.05) 60%);
+  background: rgba(0, 0, 0, 0.22);
 }
 
+/* ── Title container ── */
 .cardName {
   font-family: var(--font-heading);
-  font-size: var(--text-xl);
-  font-weight: var(--font-bold);
+  font-size: var(--text-base);
+  font-weight: var(--font-regular);
   color: var(--color-neutral-light);
-  /* color: rgb(104, 100, 100); */
-  margin-bottom: var(--space-1);
-  
-
+  margin: 0;
+  line-height: var(--leading-tight);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.cardCount {
-  font-family: var(--font-ui);
+/* Primera línea: peso normal, ligeramente más pequeña */
+.cardNamePrefix {
+  display: block;
+  font-weight: var(--font-regular);
   font-size: var(--text-sm);
-  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: var(--tracking-wide);
+  text-transform: capitalize;
+}
+
+/* Segunda línea: bold y grande, estilo Econo */
+.cardNameBold {
+  display: block;
+  font-weight: var(--font-bold);
+  font-size: var(--text-lg);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  line-height: 1.1;
 }
 
 .viewAll {
@@ -106,20 +128,24 @@
 }
 
 /* ── Responsive ── */
+@media (max-width: 1280px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
+  }
+}
+
 @media (max-width: 1024px) {
   .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .card:nth-child(1) {
-    grid-column: span 1;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
   }
 }
 
 @media (max-width: 768px) {
   .grid {
-    grid-template-columns: 1fr;
-    gap: var(--space-4);
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-3);
     padding: 0 var(--space-4);
   }
 
@@ -128,6 +154,22 @@
   }
 
   .card {
-    aspect-ratio: 16/9;
+    aspect-ratio: 4/5;
+  }
+}
+
+@media (max-width: 480px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-3);
+    padding: 0 var(--space-3);
+  }
+
+  .card {
+    aspect-ratio: 3/4;
+  }
+
+  .cardNameBold {
+    font-size: var(--text-base);
   }
 }

--- a/frontend/src/features/home/CategoryGrid/CategoryGrid.tsx
+++ b/frontend/src/features/home/CategoryGrid/CategoryGrid.tsx
@@ -3,6 +3,38 @@ import { categories } from '../../../data/mock';
 import { Button } from '../../../components/ui/Button/Button';
 import styles from './CategoryGrid.module.css';
 
+/**
+ * Divide el nombre de la categoría en dos partes:
+ * - prefix: primera(s) palabra(s) en peso regular
+ * - bold: última(s) palabra(s) en negrita
+ *
+ * Regla: si el nombre contiene "para" o "y", se parte tras esa palabra.
+ * Si empieza con "Especial", se parte tras "Especial".
+ * En otro caso todo va en bold.
+ */
+function splitCategoryName(name: string): { prefix: string; bold: string } {
+  const lowerName = name.toLowerCase();
+
+  const splitWords = ['para', 'y'];
+  for (const word of splitWords) {
+    const idx = lowerName.indexOf(` ${word} `);
+    if (idx !== -1) {
+      const splitIdx = idx + word.length + 1;
+      return {
+        prefix: name.slice(0, splitIdx + 1).trim(),
+        bold: name.slice(splitIdx + 1).trim(),
+      };
+    }
+  }
+
+  if (name.toLowerCase().startsWith('especial')) {
+    const rest = name.slice('especial'.length).trim();
+    return { prefix: 'Especial', bold: rest };
+  }
+
+  return { prefix: '', bold: name };
+}
+
 export function CategoryGrid() {
   const featured = categories.slice(0, 6);
 
@@ -17,28 +49,33 @@ export function CategoryGrid() {
       </div>
 
       <div className={styles.grid}>
-        {featured.map((cat) => (
-          <Link
-            key={cat.id}
-            to={`/productos?category=${cat.slug}`}
-            className={styles.card}
-            aria-label={`Ver categoría ${cat.name}`}
-          >
-            <img
-              className={styles.cardImage}
-              src={cat.image}
-              alt={cat.name}
-              loading="lazy"
-              decoding="async"
-            />
-            <div className={styles.cardOverlay}>
-              <h3 className={styles.cardName}>{cat.name}</h3>
-              {/* <span className={styles.cardCount}>
-                {cat.itemCount} productos
-              </span> */}
-            </div>
-          </Link>
-        ))}
+        {featured.map((cat) => {
+          const { prefix, bold } = splitCategoryName(cat.name);
+          return (
+            <Link
+              key={cat.id}
+              to={`/productos?category=${cat.slug}`}
+              className={styles.card}
+              aria-label={`Ver categoría ${cat.name}`}
+            >
+              <img
+                className={styles.cardImage}
+                src={cat.image}
+                alt={cat.name}
+                loading="lazy"
+                decoding="async"
+              />
+              <div className={styles.cardOverlay}>
+                <h3 className={styles.cardName}>
+                  {prefix && (
+                    <span className={styles.cardNamePrefix}>{prefix}</span>
+                  )}
+                  <strong className={styles.cardNameBold}>{bold}</strong>
+                </h3>
+              </div>
+            </Link>
+          );
+        })}
       </div>
 
       <div className={styles.viewAll}>


### PR DESCRIPTION
**CategoryGrid.tsx** — se añadió la función `splitCategoryName()` que divide el nombre en:
- `prefix` → texto en peso normal (ej: "Todo para", "Bar y", "Especial")
- `bold` → texto en negrita (ej: "LA COCINA", "COCTELERÍA", "FERRETERÍA")

El `h3` ahora renderiza un `<span>` para el prefijo y un `<strong>` para la parte en negrita, igual al estilo Econo.

---

**CategoryGrid.module.css** — cambios principales:

| Propiedad | Antes | Ahora |
|---|---|---|
| `aspect-ratio` | `4/3` (horizontal) | `3/4` (vertical, como Econo) | | `border-radius` | `--radius-xl` (16px) | `--radius-2xl` (24px) | | Overlay | `linear-gradient` muy oscuro (90% negro) | `rgba(0,0,0,0.32)` uniforme y sutil | | Título | Todo bold, tamaño fijo | Dos líneas: `--text-sm` regular + `--text-lg` uppercase bold | | Hover | Solo zoom imagen | `translateY(-4px)` + zoom imagen | | Responsive | 2 cols → 1 col | 6 → 3 → 2 cols (cuadrícula más densa como Econo) |

```
- [x] Actualizar CategoryGrid.tsx con nueva estructura
- [x] Rediseñar CategoryGrid.module.css estilo Econo
```

Made changes.