### PR TITLE
Esto es lo que se implementó para replicar el hover de Econo:

### DIFF
--- a/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
+++ b/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
@@ -52,25 +52,60 @@
   cursor: pointer;
   text-decoration: none;
   display: block;
-  box-shadow: var(--shadow-lg);
-  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  /* Sombra base sutil, idéntica a Econo en reposo */
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.10),
+    0 1px 3px rgba(0, 0, 0, 0.08);
+  /* Elevación + sombra en 180ms, igual de rápido que Econo */
+  transition:
+    transform 180ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    box-shadow 180ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  /* Fuerza compositing en GPU para evitar parpadeos */
+  will-change: transform, box-shadow;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-xl);
+/* Hover desktop */
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-6px) scale(1.01);
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.18),
+    0 4px 10px rgba(0, 0, 0, 0.12);
+  outline: none;
+}
+
+/* Active (press) — feedback táctil */
+.card:active {
+  transform: translateY(-2px) scale(1.005);
+  box-shadow:
+    0 6px 14px rgba(0, 0, 0, 0.14),
+    0 2px 6px rgba(0, 0, 0, 0.10);
+  transition-duration: 80ms;
 }
 
 .cardImage {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform var(--transition-slow);
-  filter: brightness(1.05) saturate(1.05);
+  /* Zoom ligeramente más marcado que Econo, en sintonía con la elevación */
+  transition: transform 320ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              filter 320ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  filter: brightness(1.0) saturate(1.0);
+  will-change: transform, filter;
 }
 
-.card:hover .cardImage {
-  transform: scale(1.06);
+.card:hover .cardImage,
+.card:focus-visible .cardImage {
+  transform: scale(1.08);
+  /* Ligero boost de brillo al hacer hover, igual que en Econo */
+  filter: brightness(1.10) saturate(1.08);
+}
+
+.card:active .cardImage {
+  transform: scale(1.04);
+  filter: brightness(1.05) saturate(1.04);
 }
 
 /* ── Overlay: semitransparente centrado estilo Econo ── */
@@ -82,11 +117,17 @@
   flex-direction: column;
   justify-content: flex-end;
   padding: var(--space-5) var(--space-4);
-  transition: background var(--transition-base);
+  transition: background 180ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-.card:hover .cardOverlay {
-  background: rgba(0, 0, 0, 0.22);
+/* Al hacer hover el overlay se aclara, dejando ver mejor la imagen (Econo) */
+.card:hover .cardOverlay,
+.card:focus-visible .cardOverlay {
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.card:active .cardOverlay {
+  background: rgba(0, 0, 0, 0.28);
 }
 
 /* ── Title container ── */


### PR DESCRIPTION
| Aspecto | Detalle |
|---|---|
| **Elevación** | `translateY(-6px) scale(1.01)` — la card sube y crece levemente, igual que Econo | | **Sombra** | Sombra base sutil → sombra más profunda y difusa en hover (`box-shadow` multicapa) | | **Timing** | `180ms cubic-bezier(0.25, 0.46, 0.45, 0.94)` — arranque suave, salida rápida, sin parpadeo | | **Zoom imagen** | `scale(1.08)` con `320ms` ligeramente más lento que la elevación, da sensación de profundidad | | **Brillo** | `brightness(1.10) saturate(1.08)` en hover — imagen más viva al pasar el cursor | | **Overlay** | Se aclara de `0.32` → `0.18` dejando la imagen más visible (comportamiento Econo) | | **GPU** | `will-change: transform` + `backface-visibility: hidden` para evitar parpadeos | | **Mobile / touch** | `:active` da feedback táctil inmediato (80ms) con elevación y zoom reducidos | | **Accesibilidad** | `:focus-visible` aplica el mismo efecto para navegación por teclado |

Made changes.