### PR TITLE
Esto es lo que se implementó para garantizar legibilidad sobre cualqu…

### DIFF
--- a/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
+++ b/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
@@ -108,29 +108,65 @@
   filter: brightness(1.05) saturate(1.04);
 }
 
-/* ── Overlay: semitransparente centrado estilo Econo ── */
+/* ── Overlay base: velo muy sutil sobre toda la card ── */
 .cardOverlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.32);
+  /*
+   * Dos capas de gradiente combinadas:
+   * 1) Esquina superior-izquierda: mancha oscura donde vive el texto
+   * 2) Borde inferior: degradado ligero para anclar visualmente la card
+   * Resultado: texto siempre legible sin importar la imagen (claro u oscuro)
+   */
+  background:
+    radial-gradient(
+      ellipse 80% 60% at 0% 0%,
+      rgba(0, 0, 0, 0.52) 0%,
+      rgba(0, 0, 0, 0.0) 70%
+    ),
+    linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.28) 0%,
+      rgba(0, 0, 0, 0.0) 35%
+    );
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  padding: var(--space-5) var(--space-4);
+  justify-content: flex-start;   /* texto arriba, igual que Econo */
+  padding: var(--space-4) var(--space-4);
   transition: background 180ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-/* Al hacer hover el overlay se aclara, dejando ver mejor la imagen (Econo) */
+/* Hover: el velo superior se aclara para mostrar más la imagen */
 .card:hover .cardOverlay,
 .card:focus-visible .cardOverlay {
-  background: rgba(0, 0, 0, 0.18);
+  background:
+    radial-gradient(
+      ellipse 80% 60% at 0% 0%,
+      rgba(0, 0, 0, 0.42) 0%,
+      rgba(0, 0, 0, 0.0) 70%
+    ),
+    linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.18) 0%,
+      rgba(0, 0, 0, 0.0) 35%
+    );
 }
 
 .card:active .cardOverlay {
-  background: rgba(0, 0, 0, 0.28);
+  background:
+    radial-gradient(
+      ellipse 80% 60% at 0% 0%,
+      rgba(0, 0, 0, 0.48) 0%,
+      rgba(0, 0, 0, 0.0) 70%
+    ),
+    linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.24) 0%,
+      rgba(0, 0, 0, 0.0) 35%
+    );
 }
 
-/* ── Title container ── */
+/* ── Bloque de texto ── */
 .cardName {
   font-family: var(--font-heading);
   font-size: var(--text-base);
@@ -138,19 +174,34 @@
   color: var(--color-neutral-light);
   margin: 0;
   line-height: var(--leading-tight);
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
+  /*
+   * text-shadow múltiple:
+   * - capa 1: sombra directa muy densa bajo cada glifo
+   * - capa 2: halo difuso para fondos complejos
+   * - capa 3: contorno tenue para imágenes muy claras
+   * Garantiza legibilidad sobre CUALQUIER imagen
+   */
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.90),
+    0 2px 8px rgba(0, 0, 0, 0.70),
+    0 0px 16px rgba(0, 0, 0, 0.50);
 }
 
-/* Primera línea: peso normal, ligeramente más pequeña */
+/* Primera línea: peso normal, ligeramente más pequeña — idéntico a Econo */
 .cardNamePrefix {
   display: block;
   font-weight: var(--font-regular);
   font-size: var(--text-sm);
   letter-spacing: var(--tracking-wide);
   text-transform: capitalize;
+  /* Sombra extra en la línea pequeña para no perder legibilidad */
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.95),
+    0 2px 8px rgba(0, 0, 0, 0.75),
+    0 0px 16px rgba(0, 0, 0, 0.55);
 }
 
 /* Segunda línea: bold y grande, estilo Econo */
@@ -161,6 +212,11 @@
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
   line-height: 1.1;
+  /* El bold ya tiene más masa visual; la sombra refuerza sobre fondos claros */
+  text-shadow:
+    0 1px 4px rgba(0, 0, 0, 0.90),
+    0 3px 10px rgba(0, 0, 0, 0.65),
+    0 0px 20px rgba(0, 0, 0, 0.45);
 }
 
 .viewAll {


### PR DESCRIPTION
…ier imagen:

Overlay doble gradiente (reemplaza el rgba plano):

Capa 1 — radial-gradient en esquina superior-izquierda: mancha oscura exactamente donde vive el texto, se desvanece hacia la imagen. Igual a como lo hace Econo. Capa 2 — linear-gradient en borde inferior: anclaje visual sutil que evita que el borde de la card "flote". text-shadow triple capa en cada elemento de texto:

Capa	Efecto
0 1px 3px rgba(0,0,0,0.90)	Sombra directa densa bajo cada glifo 0 2px 8px rgba(0,0,0,0.70)	Halo difuso para fondos con texturas complejas 0 0px 16px rgba(0,0,0,0.50)	Resplandor oscuro amplio para imágenes muy claras El .cardNamePrefix (línea pequeña) tiene sombras aún más intensas porque al ser texto más fino es más vulnerable a perder contraste.

Texto posicionado en justify-content: flex-start (arriba), replicando exactamente el layout de Econo visible en la imagen de referencia.