### PR TITLE
Cambio realizado: El estado :focus-visible tenía outline: none, elimi…

### DIFF
--- a/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
+++ b/frontend/src/features/home/CategoryGrid/CategoryGrid.module.css
@@ -75,11 +75,17 @@
 }
 
 /* Hover desktop — sombra elevada usando token xl */
-.card:hover,
+.card:hover {
+  transform: translateY(-6px) scale(1.01);
+  box-shadow: var(--shadow-xl);
+}
+
+/* Focus visible — ring accesible para navegación por teclado */
 .card:focus-visible {
   transform: translateY(-6px) scale(1.01);
   box-shadow: var(--shadow-xl);
-  outline: none;
+  outline: 3px solid var(--color-primary);
+  outline-offset: 4px;
 }
 
 /* Active (press) — feedback táctil con token sm */


### PR DESCRIPTION
…nando el indicador visual de teclado. Lo separé del :hover y añadí:

.card:focus-visible {
  transform: translateY(-6px) scale(1.01);
  box-shadow: var(--shadow-xl);
  outline: 3px solid var(--color-primary);
  outline-offset: 4px;
}