### PR TITLE
Lo que fue implementado en /admin/categorias:

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import { AdminReports } from './pages/Admin/sections/AdminReports';
 import { AdminRoute } from './components/AdminRoute';
 import { AdminAuthProvider } from './context/AdminAuthContext';
 import { AdminProductsProvider } from './context/AdminProductsContext';
+import { AdminCategoriesProvider } from './context/AdminCategoriesContext';
+import { AdminCategories } from './pages/Admin/sections/AdminCategories';
 
 const router = createBrowserRouter([
   {
@@ -36,6 +38,7 @@ const router = createBrowserRouter([
     children: [
       { path: 'dashboard', element: <AdminDashboard /> },
       { path: 'productos', element: <AdminProducts /> },
+      { path: 'categorias', element: <AdminCategories /> },
       { path: 'pedidos', element: <AdminOrders /> },
       { path: 'reportes', element: <AdminReports /> },
     ],
@@ -45,11 +48,13 @@ const router = createBrowserRouter([
 function App() {
   return (
     <AdminAuthProvider>
-      <AdminProductsProvider>
-        <CartProvider>
-          <RouterProvider router={router} />
-        </CartProvider>
-      </AdminProductsProvider>
+      <AdminCategoriesProvider>
+        <AdminProductsProvider>
+          <CartProvider>
+            <RouterProvider router={router} />
+          </CartProvider>
+        </AdminProductsProvider>
+      </AdminCategoriesProvider>
     </AdminAuthProvider>
   );
 }

--- a/frontend/src/context/AdminCategoriesContext.tsx
+++ b/frontend/src/context/AdminCategoriesContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Category } from '../types';
+import { categories as mockCategories } from '../data/mock';
+
+const STORAGE_KEY = 'allmart_admin_categories';
+
+function loadCategories(): Category[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch { /* ignore */ }
+  return mockCategories;
+}
+
+function saveCategories(cats: Category[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(cats));
+}
+
+interface AdminCategoriesContextType {
+  categories: Category[];
+  addCategory: (c: Omit<Category, 'id'>) => Category;
+  updateCategory: (id: string, data: Partial<Category>) => void;
+  deleteCategory: (id: string) => void;
+  getCategory: (id: string) => Category | undefined;
+}
+
+const AdminCategoriesContext = createContext<AdminCategoriesContextType | undefined>(undefined);
+
+export function AdminCategoriesProvider({ children }: { children: ReactNode }) {
+  const [categories, setCategories] = useState<Category[]>(loadCategories);
+
+  const addCategory = (c: Omit<Category, 'id'>): Category => {
+    const newCat: Category = {
+      ...c,
+      id: `cat-${Date.now()}`,
+      slug: c.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''),
+    };
+    setCategories(prev => {
+      const next = [...prev, newCat];
+      saveCategories(next);
+      return next;
+    });
+    return newCat;
+  };
+
+  const updateCategory = (id: string, data: Partial<Category>) => {
+    setCategories(prev => {
+      const next = prev.map(c => c.id === id ? { ...c, ...data } : c);
+      saveCategories(next);
+      return next;
+    });
+  };
+
+  const deleteCategory = (id: string) => {
+    setCategories(prev => {
+      const next = prev.filter(c => c.id !== id);
+      saveCategories(next);
+      return next;
+    });
+  };
+
+  const getCategory = (id: string) => categories.find(c => c.id === id);
+
+  return (
+    <AdminCategoriesContext.Provider value={{ categories, addCategory, updateCategory, deleteCategory, getCategory }}>
+      {children}
+    </AdminCategoriesContext.Provider>
+  );
+}
+
+export function useAdminCategories() {
+  const ctx = useContext(AdminCategoriesContext);
+  if (!ctx) throw new Error('useAdminCategories debe usarse dentro de AdminCategoriesProvider');
+  return ctx;
+}

--- a/frontend/src/pages/Admin/AdminLayout.tsx
+++ b/frontend/src/pages/Admin/AdminLayout.tsx
@@ -5,6 +5,7 @@ import styles from './AdminLayout.module.css';
 const navItems = [
   { label: 'Dashboard', to: '/admin/dashboard', icon: '🏠' },
   { label: 'Productos', to: '/admin/productos', icon: '📦' },
+  { label: 'Categorías', to: '/admin/categorias', icon: '🗂️' },
   { label: 'Pedidos', to: '/admin/pedidos', icon: '🛒' },
   { label: 'Reportes', to: '/admin/reportes', icon: '📊' },
 ];

--- a/frontend/src/pages/Admin/sections/AdminCategories.module.css
+++ b/frontend/src/pages/Admin/sections/AdminCategories.module.css
@@ -1,0 +1,339 @@
+/* ============================================
+   ALLMART — ADMIN CATEGORIES
+   ============================================ */
+
+.headerTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.newBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  background: var(--color-primary);
+  color: var(--color-neutral-light);
+  border: none;
+  border-radius: 10px;
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.newBtn:hover { background: var(--color-primary-dark); }
+
+/* ── Grid de tarjetas ── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-4);
+  animation: fadeIn 0.3s both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Tarjeta de categoría ── */
+.card {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  overflow: hidden;
+  transition: box-shadow 0.15s;
+}
+.card:hover { box-shadow: 0 4px 20px rgba(118,146,130,0.12); }
+
+.cardImg {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+  display: block;
+}
+
+.cardImgPlaceholder {
+  width: 100%;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-tertiary);
+  font-size: 3rem;
+  color: var(--color-border);
+}
+
+.cardBody {
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.cardTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.cardName {
+  font-family: var(--font-heading);
+  font-size: var(--text-base);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.cardSlug {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.cardDesc {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  line-height: var(--leading-relaxed);
+}
+
+/* ── Acciones tarjeta ── */
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.editBtn, .deleteBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--text-base);
+  padding: var(--space-1) var(--space-2);
+  border-radius: 6px;
+  transition: background 0.13s;
+}
+.editBtn:hover { background: var(--color-bg-tertiary); }
+.deleteBtn:hover { background: rgba(199,80,80,0.1); }
+
+.confirmDeleteBtn, .cancelDeleteBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  border-radius: 6px;
+  padding: 2px var(--space-2);
+  cursor: pointer;
+  border: 1px solid;
+}
+.confirmDeleteBtn { background: var(--color-error); color: white; border-color: var(--color-error); }
+.confirmDeleteBtn:hover { background: #a83d3d; }
+.cancelDeleteBtn { background: var(--color-bg-secondary); color: var(--color-text-secondary); border-color: var(--color-border); }
+
+/* ── Sección de productos ── */
+.productSection {
+  border-top: 1px solid var(--color-border-light);
+  padding-top: var(--space-3);
+}
+
+.toggleProductsBtn {
+  background: none;
+  border: none;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+.toggleProductsBtn:hover { text-decoration: underline; }
+
+.productList {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.noProducts {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.productRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  background: var(--color-bg-secondary);
+  border-radius: 6px;
+  padding: var(--space-2) var(--space-3);
+}
+
+.productName {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.reassignSelect {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  outline: none;
+  flex-shrink: 0;
+}
+.reassignSelect:focus { border-color: var(--color-primary); }
+
+/* ── Modal ── */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: var(--space-4);
+  animation: fadeIn 0.2s both;
+}
+
+.panel {
+  background: var(--color-bg-primary);
+  border-radius: 16px;
+  box-shadow: 0 8px 48px rgba(0,0,0,0.18);
+  width: 100%;
+  max-width: 480px;
+  animation: slideUp 0.25s both;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.panelTitle {
+  font-family: var(--font-heading);
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  font-size: var(--text-lg);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+.closeBtn:hover { background: var(--color-bg-tertiary); }
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+}
+
+.input {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.input:focus { border-color: var(--color-primary); background: var(--color-bg-primary); }
+
+.imagePreview {
+  margin-top: var(--space-2);
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-light);
+}
+
+.error {
+  color: var(--color-error);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border-light);
+}
+
+.cancelBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: var(--space-2) var(--space-5);
+  cursor: pointer;
+}
+.cancelBtn:hover { background: var(--color-bg-tertiary); }
+
+.submitBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  background: var(--color-primary);
+  color: var(--color-neutral-light);
+  border: none;
+  border-radius: 8px;
+  padding: var(--space-2) var(--space-6);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.submitBtn:hover { background: var(--color-primary-dark); }

--- a/frontend/src/pages/Admin/sections/AdminCategories.tsx
+++ b/frontend/src/pages/Admin/sections/AdminCategories.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import { useAdminCategories } from '../../../context/AdminCategoriesContext';
+import { useAdminProducts } from '../../../context/AdminProductsContext';
+import sectionStyles from './AdminSection.module.css';
+import styles from './AdminCategories.module.css';
+
+const EMPTY = { name: '', description: '', image: '', itemCount: 0 };
+
+export function AdminCategories() {
+  const { categories, addCategory, updateCategory, deleteCategory } = useAdminCategories();
+  const { products, updateProduct } = useAdminProducts();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [form, setForm] = useState(EMPTY);
+  const [error, setError] = useState('');
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [assignCatId, setAssignCatId] = useState<string | null>(null);
+
+  const openNew = () => { setEditId(null); setForm(EMPTY); setError(''); setShowForm(true); };
+  const openEdit = (id: string) => {
+    const c = categories.find(c => c.id === id);
+    if (!c) return;
+    setEditId(id);
+    setForm({ name: c.name, description: c.description ?? '', image: c.image ?? '', itemCount: c.itemCount ?? 0 });
+    setError('');
+    setShowForm(true);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim()) return setError('El nombre es obligatorio');
+    setError('');
+    if (editId) {
+      updateCategory(editId, {
+        name: form.name.trim(),
+        description: form.description.trim() || undefined,
+        image: form.image.trim() || undefined,
+      });
+    } else {
+      addCategory({
+        name: form.name.trim(),
+        slug: '',
+        description: form.description.trim() || undefined,
+        image: form.image.trim() || undefined,
+        itemCount: 0,
+      });
+    }
+    setShowForm(false);
+  };
+
+  const handleDelete = (id: string) => {
+    // Productos con esta categoría quedan sin categoría asignada
+    deleteCategory(id);
+    setDeleteConfirm(null);
+  };
+
+  // Productos de una categoría
+  const productsOfCat = (catId: string) => products.filter(p => p.category.id === catId);
+
+  // Reasignar producto a otra categoría
+  const reassignProduct = (productId: string, newCatId: string) => {
+    const newCat = categories.find(c => c.id === newCatId);
+    if (!newCat) return;
+    updateProduct(productId, { category: newCat });
+  };
+
+  return (
+    <div className={sectionStyles.page}>
+
+      {/* Header */}
+      <div className={sectionStyles.header}>
+        <div className={styles.headerTop}>
+          <div>
+            <span className={sectionStyles.label}>Administración</span>
+            <h1 className={sectionStyles.title}>
+              <span className={sectionStyles.icon}>🗂️</span> Categorías
+            </h1>
+            <p className={sectionStyles.subtitle}>
+              Creá, editá y eliminá categorías. Asigná productos a cada una.
+            </p>
+          </div>
+          <button className={styles.newBtn} onClick={openNew}>+ Nueva categoría</button>
+        </div>
+      </div>
+
+      {/* Listado */}
+      {categories.length === 0 ? (
+        <div className={sectionStyles.emptyState}>
+          <span className={sectionStyles.emptyIcon}>🗂️</span>
+          <p className={sectionStyles.emptyText}>No hay categorías creadas.</p>
+        </div>
+      ) : (
+        <div className={styles.grid}>
+          {categories.map(cat => {
+            const catProducts = productsOfCat(cat.id);
+            return (
+              <div key={cat.id} className={styles.card}>
+                {/* Imagen preview */}
+                {cat.image ? (
+                  <img src={cat.image} alt={cat.name} className={styles.cardImg}
+                    onError={e => (e.currentTarget.style.display = 'none')} />
+                ) : (
+                  <div className={styles.cardImgPlaceholder}>🗂️</div>
+                )}
+
+                <div className={styles.cardBody}>
+                  <div className={styles.cardTop}>
+                    <div>
+                      <h3 className={styles.cardName}>{cat.name}</h3>
+                      <span className={styles.cardSlug}>/{cat.slug}</span>
+                    </div>
+                    <div className={styles.cardActions}>
+                      <button className={styles.editBtn} onClick={() => openEdit(cat.id)} title="Editar">✏️</button>
+                      {deleteConfirm === cat.id ? (
+                        <>
+                          <button className={styles.confirmDeleteBtn} onClick={() => handleDelete(cat.id)}>Confirmar</button>
+                          <button className={styles.cancelDeleteBtn} onClick={() => setDeleteConfirm(null)}>Cancelar</button>
+                        </>
+                      ) : (
+                        <button className={styles.deleteBtn} onClick={() => setDeleteConfirm(cat.id)} title="Eliminar">🗑️</button>
+                      )}
+                    </div>
+                  </div>
+
+                  {cat.description && <p className={styles.cardDesc}>{cat.description}</p>}
+
+                  {/* Productos de esta categoría */}
+                  <div className={styles.productSection}>
+                    <button
+                      className={styles.toggleProductsBtn}
+                      onClick={() => setAssignCatId(assignCatId === cat.id ? null : cat.id)}
+                    >
+                      📦 {catProducts.length} producto{catProducts.length !== 1 ? 's' : ''}
+                      {assignCatId === cat.id ? ' ▲' : ' ▼'}
+                    </button>
+
+                    {assignCatId === cat.id && (
+                      <div className={styles.productList}>
+                        {catProducts.length === 0 ? (
+                          <p className={styles.noProducts}>Sin productos asignados.</p>
+                        ) : (
+                          catProducts.map(p => (
+                            <div key={p.id} className={styles.productRow}>
+                              <span className={styles.productName}>{p.name}</span>
+                              <select
+                                className={styles.reassignSelect}
+                                value={p.category.id}
+                                onChange={e => reassignProduct(p.id, e.target.value)}
+                              >
+                                {categories.map(c => (
+                                  <option key={c.id} value={c.id}>{c.name}</option>
+                                ))}
+                              </select>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Modal formulario */}
+      {showForm && (
+        <div className={styles.backdrop} onClick={e => e.target === e.currentTarget && setShowForm(false)}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>{editId ? 'Editar categoría' : 'Nueva categoría'}</h2>
+              <button className={styles.closeBtn} onClick={() => setShowForm(false)}>✕</button>
+            </div>
+            <form className={styles.form} onSubmit={handleSubmit}>
+              <div className={styles.field}>
+                <label className={styles.label}>Nombre *</label>
+                <input className={styles.input} value={form.name}
+                  onChange={e => setForm(f => ({ ...f, name: e.target.value }))} required />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label}>Descripción</label>
+                <input className={styles.input} value={form.description}
+                  onChange={e => setForm(f => ({ ...f, description: e.target.value }))} />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label}>URL de imagen</label>
+                <input className={styles.input} value={form.image}
+                  onChange={e => setForm(f => ({ ...f, image: e.target.value }))}
+                  placeholder="https://..." />
+                {form.image && (
+                  <img src={form.image} alt="preview" className={styles.imagePreview}
+                    onError={e => (e.currentTarget.style.display = 'none')} />
+                )}
+              </div>
+              {error && <p className={styles.error}>{error}</p>}
+              <div className={styles.formActions}>
+                <button type="button" className={styles.cancelBtn} onClick={() => setShowForm(false)}>Cancelar</button>
+                <button type="submit" className={styles.submitBtn}>{editId ? 'Guardar cambios' : 'Crear categoría'}</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Admin/sections/AdminProductForm.tsx
+++ b/frontend/src/pages/Admin/sections/AdminProductForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { AdminProduct, ProductVariant } from '../../../context/AdminProductsContext';
 import { useAdminProducts } from '../../../context/AdminProductsContext';
+import { useAdminCategories } from '../../../context/AdminCategoriesContext';
 import styles from './AdminProductForm.module.css';
 
 interface Props {
@@ -29,7 +30,8 @@ const EMPTY: Omit<AdminProduct, 'id'> = {
 };
 
 export function AdminProductForm({ productId, onClose }: Props) {
-  const { addProduct, updateProduct, getProduct, categories } = useAdminProducts();
+  const { addProduct, updateProduct, getProduct } = useAdminProducts();
+  const { categories } = useAdminCategories();
   const isEdit = !!productId;
 
   const [form, setForm] = useState<Omit<AdminProduct, 'id'>>(EMPTY);

--- a/frontend/src/pages/Admin/sections/AdminProducts.tsx
+++ b/frontend/src/pages/Admin/sections/AdminProducts.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAdminProducts } from '../../../context/AdminProductsContext';
+import { useAdminCategories } from '../../../context/AdminCategoriesContext';
 import { AdminProductForm } from './AdminProductForm';
 import sectionStyles from './AdminSection.module.css';
 import styles from './AdminProducts.module.css';
@@ -12,7 +13,7 @@ export function AdminProducts() {
   const [showForm, setShowForm] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
 
-  const { categories } = useAdminProducts();
+  const { categories } = useAdminCategories();
 
   const filtered = products.filter(p => {
     const matchSearch =


### PR DESCRIPTION
Listado en cards con imagen, nombre, slug y descripción Alta de categoría con formulario modal (nombre, descripción, URL de imagen con preview) Edición con formulario pre-cargado
Eliminación con confirmación inline
Relación producto-categoría: cada tarjeta muestra cuántos productos tiene, y al expandirla se puede reasignar cada producto a otra categoría directamente con un <select>
Las categorías gestionadas se usan automáticamente en el formulario de productos (los selects de categoría usan useAdminCategories) Persistencia en localStorage, inicializadas con las categorías del mock