### PR TITLE
Implementación: Confirmación de pago por WhatsApp

### DIFF
--- a/frontend/src/context/AdminOrdersContext.tsx
+++ b/frontend/src/context/AdminOrdersContext.tsx
@@ -18,6 +18,8 @@ export interface OrderItem {
   unitPrice: number;
 }
 
+export type PaymentStatus = 'no-abonado' | 'abonado';
+
 export interface Order {
   id: string;
   createdAt: string; // ISO 8601
@@ -29,6 +31,8 @@ export interface Order {
   items: OrderItem[];
   total: number;
   status: OrderStatus;
+  paymentStatus?: PaymentStatus;
+  paidAt?: string; // ISO 8601
   notes?: string;
 }
 
@@ -112,6 +116,7 @@ interface AdminOrdersContextType {
   updateOrder: (id: string, data: Partial<Order>) => void;
   deleteOrder: (id: string) => void;
   getOrder: (id: string) => Order | undefined;
+  markAsPaid: (id: string) => void;
 }
 
 const AdminOrdersContext = createContext<AdminOrdersContextType | undefined>(undefined);
@@ -159,9 +164,21 @@ export function AdminOrdersProvider({ children }: { children: ReactNode }) {
 
   const getOrder = (id: string) => orders.find(o => o.id === id);
 
+  const markAsPaid = (id: string) => {
+    setOrders(prev => {
+      const next = prev.map(o =>
+        o.id === id
+          ? { ...o, paymentStatus: 'abonado' as PaymentStatus, paidAt: new Date().toISOString() }
+          : o
+      );
+      saveOrders(next);
+      return next;
+    });
+  };
+
   return (
     <AdminOrdersContext.Provider value={{
-      orders, addOrder, updateOrderStatus, updateOrder, deleteOrder, getOrder,
+      orders, addOrder, updateOrderStatus, updateOrder, deleteOrder, getOrder, markAsPaid,
     }}>
       {children}
     </AdminOrdersContext.Provider>

--- a/frontend/src/pages/Admin/sections/AdminOrders.module.css
+++ b/frontend/src/pages/Admin/sections/AdminOrders.module.css
@@ -5,7 +5,7 @@
 /* ── Tarjetas de resumen ── */
 .summary {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: var(--space-3);
 }
 
@@ -66,11 +66,13 @@
 .cardPreparacion::before { background: #8b5cf6; }
 .cardEnviado::before   { background: var(--color-primary, #10b981); }
 .cardEntregado::before { background: #22c55e; }
+.cardAbonado::before   { background: #25D366; }
 
 .numPendiente   { color: #d97706; }
 .numPreparacion { color: #7c3aed; }
 .numEnviado     { color: var(--color-primary); }
 .numEntregado   { color: #16a34a; }
+.numAbonado     { color: #128C48; }
 
 /* ── Filtros ── */
 .filters {
@@ -438,6 +440,114 @@
 .statusEnviado     { background: #d1fae5; color: #065f46; }
 .statusEntregado   { background: #dcfce7; color: #166534; }
 .statusCancelado   { background: #fee2e2; color: #991b1b; }
+
+/* ── Badges de pago ── */
+.paymentBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  border-radius: 999px;
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.paymentAbonado    { background: #dcfce7; color: #128C48; }
+.paymentNoAbonado  { background: #f3f4f6; color: #6b7280; }
+
+.paymentBadgeInline {
+  margin-left: var(--space-2);
+  font-size: 0.65rem;
+  padding: 2px 8px;
+}
+
+/* ── Fila de pago en modal ── */
+.paymentRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.paidAt {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* ── Sección de acción WhatsApp ── */
+.whatsappActions {
+  margin-top: var(--space-3);
+}
+
+.whatsappBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  background: #25D366;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: var(--space-3) var(--space-5);
+  cursor: pointer;
+  transition: background 0.18s, transform 0.12s, box-shadow 0.18s;
+  box-shadow: 0 2px 8px rgba(37, 211, 102, 0.25);
+}
+.whatsappBtn:hover {
+  background: #128C48;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(37, 211, 102, 0.35);
+}
+.whatsappBtn:active { transform: translateY(0); }
+
+.whatsappIcon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.confirmPaidBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  background: color-mix(in srgb, #25D366 8%, var(--color-bg-secondary));
+  border: 1px solid #b7f0cc;
+  border-radius: 10px;
+  padding: var(--space-4);
+}
+
+.confirmPaidText {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.confirmPaidActions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.whatsappBtnConfirm {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  background: #25D366;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: var(--space-2) var(--space-5);
+  cursor: pointer;
+  transition: background 0.15s;
+  flex: 1;
+}
+.whatsappBtnConfirm:hover { background: #128C48; }
 
 /* ── Modal backdrop ── */
 .backdrop {


### PR DESCRIPTION
Archivos modificados:

AdminOrdersContext.tsx

Nuevo tipo PaymentStatus: 'no-abonado' | 'abonado' Nuevos campos en Order: paymentStatus? y paidAt?
Nueva función markAsPaid(id) que guarda el estado 'abonado' con timestamp AdminOrders.tsx

Sección "Pago" en el modal con:
Badge de estado (sin abonar / abonado) con fecha/hora de confirmación Botón 💬 "Marcar como abonado" (verde WhatsApp #25D366) Paso de confirmación antes de aplicar el cambio
Badge inline "✓ Abonado" en la tabla y en las tarjetas mobile Tarjeta de resumen "Abonados" con acento verde WhatsApp (grid ampliado a 6 columnas) AdminOrders.module.css

Clases .paymentAbonado, .paymentNoAbonado, .paymentBadge, .paymentBadgeInline Estilos .whatsappBtn, .whatsappBtnConfirm con color #25D366 / hover #128C48 Caja de confirmación .confirmPaidBox con tinte verde suave Tarjeta resumen .cardAbonado y .numAbonado