### PR TITLE
Historial y seguimiento de pedidos

### DIFF
--- a/frontend/src/context/AdminOrdersContext.tsx
+++ b/frontend/src/context/AdminOrdersContext.tsx
@@ -20,6 +20,12 @@ export interface OrderItem {
 
 export type PaymentStatus = 'no-abonado' | 'abonado';
 
+export interface OrderHistoryEntry {
+  status: OrderStatus;
+  changedAt: string; // ISO 8601
+  note?: string;
+}
+
 export interface Order {
   id: string;
   createdAt: string; // ISO 8601
@@ -34,16 +40,20 @@ export interface Order {
   paymentStatus?: PaymentStatus;
   paidAt?: string; // ISO 8601
   notes?: string;
+  statusHistory?: OrderHistoryEntry[];
 }
 
 /* ── Storage ────────────────────────────────────────────────────── */
 export const ORDERS_STORAGE_KEY = 'allmart_orders';
 
 /* ── Mock para demo ─────────────────────────────────────────────── */
+const _d = (daysAgo: number, extraMs = 0) =>
+  new Date(Date.now() - daysAgo * 86400000 - extraMs).toISOString();
+
 const MOCK_ORDERS: Order[] = [
   {
     id: 'ord-001',
-    createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: _d(1),
     customer: { firstName: 'Lucía', lastName: 'Fernández', email: 'lucia@ejemplo.com' },
     items: [
       { productId: 'prod-1', productName: 'Batería de Cocina Granito 5 Piezas', quantity: 1, unitPrice: 89990 },
@@ -51,40 +61,60 @@ const MOCK_ORDERS: Order[] = [
     ],
     total: 159970,
     status: 'pendiente',
+    statusHistory: [
+      { status: 'pendiente', changedAt: _d(1), note: 'Pedido recibido' },
+    ],
   },
   {
     id: 'ord-002',
-    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: _d(3),
     customer: { firstName: 'Martín', lastName: 'Gómez', email: 'martin@ejemplo.com' },
     items: [
       { productId: 'prod-2', productName: 'Molinillo de Café Premium', quantity: 1, unitPrice: 24990 },
     ],
     total: 24990,
     status: 'confirmado',
+    statusHistory: [
+      { status: 'pendiente', changedAt: _d(3), note: 'Pedido recibido' },
+      { status: 'confirmado', changedAt: _d(2, 3600000), note: 'Pago confirmado por WhatsApp' },
+    ],
   },
   {
     id: 'ord-003',
-    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: _d(5),
     customer: { firstName: 'Valentina', lastName: 'Ruiz', email: 'vale@ejemplo.com' },
     items: [
       { productId: 'prod-3', productName: 'Set Cuchillos Design con Soporte', quantity: 1, unitPrice: 48990 },
     ],
     total: 48990,
     status: 'enviado',
+    statusHistory: [
+      { status: 'pendiente', changedAt: _d(5), note: 'Pedido recibido' },
+      { status: 'confirmado', changedAt: _d(4, 7200000) },
+      { status: 'en-preparacion', changedAt: _d(3, 3600000), note: 'En armado de envío' },
+      { status: 'enviado', changedAt: _d(2), note: 'Despachado por correo Andreani — #TR8821' },
+    ],
   },
   {
     id: 'ord-004',
-    createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: _d(10),
     customer: { firstName: 'Carlos', lastName: 'Medina', email: 'carlos@ejemplo.com' },
     items: [
       { productId: 'prod-1', productName: 'Batería de Cocina Granito 5 Piezas', quantity: 2, unitPrice: 89990 },
     ],
     total: 179980,
     status: 'entregado',
+    statusHistory: [
+      { status: 'pendiente', changedAt: _d(10), note: 'Pedido recibido' },
+      { status: 'confirmado', changedAt: _d(9, 3600000) },
+      { status: 'en-preparacion', changedAt: _d(8) },
+      { status: 'enviado', changedAt: _d(6), note: 'Enviado por OCA' },
+      { status: 'entregado', changedAt: _d(4), note: 'Confirmado por cliente' },
+    ],
   },
   {
     id: 'ord-005',
-    createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: _d(15),
     customer: { firstName: 'Sofía', lastName: 'Herrera', email: 'sofia@ejemplo.com' },
     items: [
       { productId: 'prod-2', productName: 'Molinillo de Café Premium', quantity: 1, unitPrice: 24990 },
@@ -93,6 +123,11 @@ const MOCK_ORDERS: Order[] = [
     total: 73980,
     status: 'cancelado',
     notes: 'Cliente solicitó cancelar por demora.',
+    statusHistory: [
+      { status: 'pendiente', changedAt: _d(15), note: 'Pedido recibido' },
+      { status: 'confirmado', changedAt: _d(14) },
+      { status: 'cancelado', changedAt: _d(12), note: 'Cliente solicitó cancelar por demora.' },
+    ],
   },
 ];
 
@@ -112,7 +147,7 @@ function saveOrders(orders: Order[]) {
 interface AdminOrdersContextType {
   orders: Order[];
   addOrder: (order: Omit<Order, 'id' | 'createdAt'>) => Order;
-  updateOrderStatus: (id: string, status: OrderStatus) => void;
+  updateOrderStatus: (id: string, status: OrderStatus, note?: string) => void;
   updateOrder: (id: string, data: Partial<Order>) => void;
   deleteOrder: (id: string) => void;
   getOrder: (id: string) => Order | undefined;
@@ -125,10 +160,14 @@ export function AdminOrdersProvider({ children }: { children: ReactNode }) {
   const [orders, setOrders] = useState<Order[]>(loadOrders);
 
   const addOrder = (data: Omit<Order, 'id' | 'createdAt'>): Order => {
+    const now = new Date().toISOString();
     const order: Order = {
       ...data,
       id: `ord-${Date.now()}`,
-      createdAt: new Date().toISOString(),
+      createdAt: now,
+      statusHistory: [
+        { status: data.status, changedAt: now, note: 'Pedido recibido' },
+      ],
     };
     setOrders(prev => {
       const next = [order, ...prev];
@@ -138,9 +177,18 @@ export function AdminOrdersProvider({ children }: { children: ReactNode }) {
     return order;
   };
 
-  const updateOrderStatus = (id: string, status: OrderStatus) => {
+  const updateOrderStatus = (id: string, status: OrderStatus, note?: string) => {
     setOrders(prev => {
-      const next = prev.map(o => o.id === id ? { ...o, status } : o);
+      const now = new Date().toISOString();
+      const next = prev.map(o => {
+        if (o.id !== id) return o;
+        const entry: OrderHistoryEntry = { status, changedAt: now, ...(note ? { note } : {}) };
+        return {
+          ...o,
+          status,
+          statusHistory: [...(o.statusHistory ?? []), entry],
+        };
+      });
       saveOrders(next);
       return next;
     });

--- a/frontend/src/pages/Admin/sections/AdminOrders.module.css
+++ b/frontend/src/pages/Admin/sections/AdminOrders.module.css
@@ -925,3 +925,158 @@
   flex: 1;
 }
 .cancelBtn:hover { background: var(--color-bg-tertiary); }
+
+/* ── Cambio de estado con nota ── */
+.statusChangeBox {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  background: color-mix(in srgb, var(--color-primary) 6%, var(--color-bg-secondary));
+  border: 1px solid color-mix(in srgb, var(--color-primary) 25%, var(--color-border));
+  border-radius: 10px;
+  padding: var(--space-3) var(--space-4);
+}
+
+.statusNoteInput {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+.statusNoteInput:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
+}
+.statusNoteInput::placeholder { color: var(--color-text-tertiary); }
+
+.statusChangeActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.applyStatusBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: 8px;
+  padding: var(--space-2) var(--space-5);
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  flex: 1;
+}
+.applyStatusBtn:hover { background: var(--color-primary-dark); transform: translateY(-1px); }
+.applyStatusBtn:active { transform: translateY(0); }
+
+/* ── Timeline de historial de estados ── */
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.timelineItem {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.timelineItemCurrent .timelineDot {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.timelineDotWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 2.25rem;
+  padding-top: 2px;
+}
+
+.timelineDot {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--color-bg-tertiary);
+  border: 2px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  transition: box-shadow 0.2s;
+}
+
+.timelineLine {
+  width: 2px;
+  flex: 1;
+  min-height: var(--space-6);
+  background: var(--color-border);
+  margin-top: 2px;
+  border-radius: 1px;
+}
+
+.timelineContent {
+  flex: 1;
+  padding-bottom: var(--space-5);
+  min-width: 0;
+}
+
+.timelineHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-1);
+}
+
+.timelineCurrentTag {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-primary-dark);
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.timelineDate {
+  display: block;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin-bottom: 2px;
+}
+
+.timelineNote {
+  margin: var(--space-1) 0 0;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  border-left: 3px solid var(--color-primary-light);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 0 6px 6px 0;
+}
+
+.timelineEmpty {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}


### PR DESCRIPTION
AdminOrdersContext.tsx

Nuevo tipo OrderHistoryEntry { status, changedAt, note? } Campo statusHistory?: OrderHistoryEntry[] en Order addOrder → siembra historial con entrada inicial "Pedido recibido" updateOrderStatus(id, status, note?) → agrega automáticamente cada cambio al historial Mock data actualizado con historial realista de múltiples estados y notas AdminOrders.tsx

Componente OrderTimeline: timeline visual invertido (más reciente primero) con dot, línea conectora, badge de estado, fecha/hora y nota cuando existe Sección "Historial de estados" en el modal, justo debajo del selector de estado Nota en cambio de estado: al seleccionar un nuevo estado, aparece un input de nota opcional + botones "Guardar cambio" / "Cancelar" antes de aplicar — el cambio queda registrado en el historial STATUS_ICONS por cada estado (⏳ ✔️ 🔧 🚚 ✅ ❌)
Tag "Estado actual" destacado en la entrada más reciente del timeline AdminOrders.module.css

.statusChangeBox, .statusNoteInput, .applyStatusBtn — caja y controles del cambio con nota .timeline, .timelineItem, .timelineDotWrap, .timelineDot, .timelineLine — estructura visual del timeline .timelineContent, .timelineHeader, .timelineDate, .timelineNote, .timelineCurrentTag — contenido de cada entrada, respetando los tokens de color de la marca (--color-primary, --color-primary-light, --color-bg-tertiary)