### PR TITLE
el resumen de todo lo implementado:

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,20 +1,175 @@
-# Backend base para Allmart
+# Backend Allmart — ERP-ready
 
-Este backend está preparado para ser extendido según las necesidades del proyecto. Por defecto, se incluye una estructura mínima con Node.js y Express.
+Backend de Allmart construido con **Node.js + Express + TypeScript**, diseñado con una arquitectura modular y escalable orientada a evolucionar hacia un ERP completo.
 
-## Estructura
+---
 
-- `/src` — Código fuente del backend
-- `package.json` — Dependencias y scripts
+## Filosofía de la estructura
+
+La arquitectura sigue los principios de **Separación de Responsabilidades**, **Domain Driven Design (DDD)** y **Clean Architecture**:
+
+| Capa | Carpeta | Responsabilidad |
+|------|---------|-----------------|
+| Configuración | `src/config/` | Variables de entorno y conexión a BD |
+| Tipos globales | `src/types/` | Interfaces, enums y tipos compartidos |
+| Modelos | `src/models/` | Contratos de datos por dominio |
+| Lógica de negocio | `src/services/` | Reglas de negocio puras, sin Express |
+| Presentación | `src/controllers/` | Adapta HTTP ↔ servicios |
+| Rutas | `src/routes/` | Declaración de endpoints agrupados por dominio |
+| Middlewares | `src/middlewares/` | Auth, permisos, manejo de errores |
+| Helpers | `src/utils/` | Funciones reutilizables (JWT, bcrypt, response) |
+
+> **Regla de oro:** los servicios nunca dependen de Express (sin `req`/`res`). Los controladores son delgados: sólo orquestan llamadas al servicio y devuelven la respuesta HTTP.
+
+---
+
+## Estructura de carpetas
+
+```
+backend/src/
+├── config/
+│   ├── env.ts             — Variables de entorno centralizadas
+│   └── database.ts        — Conexión a BD (preparado para PostgreSQL/MongoDB)
+├── types/
+│   ├── index.ts           — Tipos globales (ApiResponse, JwtPayload, etc.)
+│   └── enums.ts           — Enumeraciones globales (UserRole, OrderStatus, etc.)
+├── models/
+│   ├── User.ts
+│   ├── Category.ts
+│   ├── Product.ts
+│   ├── ProductVariant.ts  — Subdominio de products
+│   ├── ProductImage.ts    — Subdominio de products
+│   ├── Order.ts
+│   └── OrderItem.ts
+├── middlewares/
+│   ├── auth.ts            — Verificación JWT
+│   ├── permissions.ts     — Control de acceso por roles
+│   └── errorHandler.ts    — Manejo global de errores
+├── utils/
+│   ├── jwt.ts             — sign / verify
+│   ├── bcrypt.ts          — hash / compare
+│   └── response.ts        — sendSuccess / sendError / sendPaginated
+├── services/
+│   ├── authService.ts
+│   ├── categoriesService.ts
+│   ├── productsService.ts
+│   ├── productVariantsService.ts
+│   ├── productImagesService.ts
+│   ├── ordersService.ts
+│   └── usersService.ts
+├── controllers/
+│   └── admin/
+│       ├── authController.ts
+│       ├── categoriesController.ts
+│       ├── productsController.ts
+│       ├── productVariantsController.ts
+│       ├── productImagesController.ts
+│       ├── ordersController.ts
+│       └── usersController.ts
+├── routes/
+│   ├── index.ts           — Router raíz que monta todos los dominios
+│   └── admin/
+│       ├── auth.ts
+│       ├── categories.ts
+│       ├── products.ts    — Monta subdominios /variants e /images
+│       ├── products/
+│       │   ├── variants.ts
+│       │   └── images.ts
+│       ├── orders.ts
+│       └── users.ts
+├── app.ts                 — Configuración Express (sin arranque)
+└── index.ts               — Punto de entrada del servidor
+```
+
+---
+
+## Cómo agregar un nuevo dominio
+
+Ejemplo: agregar el dominio **Proveedores** (`suppliers`).
+
+### 1. Modelo
+```ts
+// src/models/Supplier.ts
+export interface Supplier { id: string; name: string; ... }
+export type CreateSupplierDTO = Omit<Supplier, 'id' | 'createdAt' | 'updatedAt'>;
+```
+
+### 2. Servicio
+```ts
+// src/services/suppliersService.ts
+export async function getAllSuppliers(): Promise<Supplier[]> { ... }
+export async function createSupplier(dto: CreateSupplierDTO): Promise<Supplier> { ... }
+```
+
+### 3. Controlador
+```ts
+// src/controllers/admin/suppliersController.ts
+export async function index(req, res, next) {
+  const suppliers = await suppliersService.getAllSuppliers();
+  sendSuccess(res, suppliers);
+}
+```
+
+### 4. Rutas
+```ts
+// src/routes/admin/suppliers.ts
+import { Router } from 'express';
+import * as ctrl from '../../controllers/admin/suppliersController';
+const router = Router();
+router.get('/', ctrl.index);
+export default router;
+```
+
+### 5. Montar en el router raíz
+```ts
+// src/routes/index.ts
+import suppliersRouter from './admin/suppliers';
+adminRouter.use('/suppliers', suppliersRouter);
+```
+
+---
+
+## Cómo agregar un subdominio
+
+Ejemplo: agregar **documentos** de proveedores.
+
+1. Crear `src/models/SupplierDocument.ts`
+2. Crear `src/services/supplierDocumentsService.ts`
+3. Crear `src/controllers/admin/supplierDocumentsController.ts`
+4. Crear `src/routes/admin/suppliers/documents.ts` con `Router({ mergeParams: true })`
+5. Montar en `src/routes/admin/suppliers.ts`: `router.use('/:supplierId/documents', documentsRouter)`
+
+---
 
 ## Scripts
 
-- `npm install` — Instala las dependencias
-- `npm run dev` — Inicia el servidor en modo desarrollo
-- `npm start` — Inicia el servidor en modo producción
+```bash
+npm install          # Instala dependencias
+npm run dev          # Modo desarrollo con hot-reload (ts-node-dev)
+npm run build        # Compila TypeScript → dist/
+npm start            # Inicia desde dist/ (producción)
+```
 
 ## Requisitos
-- Node.js >= 18
 
-## Extensión
-Puedes agregar controladores, rutas y modelos según crezca el proyecto.
+- Node.js >= 18
+- TypeScript >= 5
+
+## Variables de entorno
+
+Ver `.env` en la raíz del backend. Variables disponibles en `src/config/env.ts`.
+
+---
+
+## Endopoints disponibles
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| POST | `/api/admin/auth/login` | Login admin |
+| GET | `/api/admin/products` | Listar productos |
+| POST | `/api/admin/products` | Crear producto |
+| GET | `/api/admin/products/:id/variants` | Variantes de producto |
+| GET | `/api/admin/products/:id/images` | Imágenes de producto |
+| GET | `/api/admin/categories` | Listar categorías |
+| GET | `/api/admin/orders` | Listar pedidos |
+| GET | `/api/admin/users` | Listar usuarios (solo admin) |

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,11 +12,262 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^4.18.2",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "^9.0.3",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "nodemon": "^3.0.0"
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.7",
+        "@types/node": "^20.14.0",
+        "@types/uuid": "^9.0.8",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.4.5"
       }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -29,6 +280,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/anymatch": {
@@ -44,6 +321,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -133,6 +417,13 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -257,6 +548,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -285,6 +583,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -309,6 +617,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -475,6 +793,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -536,6 +861,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -559,16 +906,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -627,12 +964,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -660,6 +1002,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -786,6 +1144,13 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -868,6 +1233,29 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -882,60 +1270,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/nodemon": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
-      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -980,6 +1314,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -988,6 +1332,23 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -1020,13 +1381,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -1078,6 +1432,41 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/safe-buffer": {
@@ -1241,17 +1630,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/statuses": {
@@ -1263,17 +1660,37 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-regex-range": {
@@ -1298,14 +1715,106 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "bin": {
-        "nodetouch": "bin/nodetouch.js"
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "bin": {
+        "ts-node-dev": "lib/bin.js",
+        "tsnd": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       }
     },
     "node_modules/type-is": {
@@ -1321,10 +1830,24 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1346,6 +1869,26 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1353,6 +1896,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,20 +1,28 @@
 {
   "name": "allmart-backend",
   "version": "1.0.0",
-  "main": "src/index.js",
-  "type": "module",
+  "main": "dist/index.js",
   "scripts": {
-    "dev": "nodemon src/index.js",
-    "start": "node src/index.js"
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "^9.0.3",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.0"
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.7",
+    "@types/node": "^20.14.0",
+    "@types/uuid": "^9.0.8",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,33 @@
+/**
+ * app.ts
+ * Configuración de la aplicación Express.
+ * Separa la inicialización de la app del arranque del servidor
+ * para facilitar testing y entornos múltiples.
+ */
+
+import express from 'express';
+import cors from 'cors';
+import apiRouter from './routes';
+import { errorHandler } from './middlewares/errorHandler';
+
+const app = express();
+
+// ─── Middlewares globales ──────────────────────────────────────────────────────
+app.use(express.json());
+app.use(cors({
+  origin: process.env.CORS_ORIGIN || 'http://localhost:5173',
+  credentials: true,
+}));
+
+// ─── Health check ─────────────────────────────────────────────────────────────
+app.get('/', (_req, res) => {
+  res.json({ success: true, message: 'Backend Allmart funcionando' });
+});
+
+// ─── Rutas de la API ──────────────────────────────────────────────────────────
+app.use('/api', apiRouter);
+
+// ─── Manejo global de errores (DEBE ir al final) ───────────────────────────────
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,0 +1,17 @@
+/**
+ * config/database.ts
+ * Punto de conexión a la base de datos.
+ * Actualmente el sistema usa datos en memoria; cuando se integre
+ * una BD (PostgreSQL, MongoDB, etc.) la lógica de conexión va aquí.
+ *
+ * Ejemplo con PostgreSQL (pg / prisma / typeorm):
+ *   export const db = new Pool({ connectionString: env.DATABASE_URL });
+ *
+ * Ejemplo con MongoDB (mongoose):
+ *   export const connectDB = async () => mongoose.connect(env.DATABASE_URL);
+ */
+
+export const connectDB = async (): Promise<void> => {
+  // TODO: implementar conexión cuando se elija la BD
+  console.log('[DB] Base de datos en modo in-memory (sin conexión externa)');
+};

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,23 @@
+/**
+ * config/env.ts
+ * Centraliza la lectura y validación de variables de entorno.
+ * Agrega aquí nuevas variables a medida que el proyecto crezca.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+
+export const env = {
+  PORT: parseInt(process.env.PORT || '3001', 10),
+  JWT_SECRET: process.env.JWT_SECRET || 'allmart_super_secret',
+  NODE_ENV: process.env.NODE_ENV || 'development',
+
+  // Admin credentials (in-memory, migrate to DB when available)
+  ADMIN_USER: process.env.ADMIN_USER || 'admin',
+  ADMIN_HASH: process.env.ADMIN_HASH || '$2b$10$zLj./2iqsqnoBqxpT92mVOwUtayNkYy6tL8in443IuB82L905yOau',
+
+  EDITOR_USER: process.env.EDITOR_USER || 'editor',
+  EDITOR_HASH: process.env.EDITOR_HASH || '$2b$10$mt.YMa6mFiMmnnxRettsAO/brFQfx1rJQBWFN.HePpYNYtoj7ZRhu',
+
+  // Database — cuando se conecte una BD real, agregar aquí
+  // DATABASE_URL: process.env.DATABASE_URL || '',
+} as const;

--- a/backend/src/controllers/admin/authController.ts
+++ b/backend/src/controllers/admin/authController.ts
@@ -1,0 +1,22 @@
+/**
+ * controllers/admin/authController.ts
+ * Controlador de autenticación del panel de administración.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import * as authService from '../../services/authService';
+import { sendSuccess } from '../../utils/response';
+
+export async function loginController(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { user, password } = req.body as { user?: string; password?: string };
+    if (!user || !password) {
+      res.status(400).json({ success: false, message: 'Usuario y contraseña requeridos' });
+      return;
+    }
+    const result = await authService.login(user, password);
+    sendSuccess(res, result, 200, 'Autenticación exitosa');
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/controllers/admin/categoriesController.ts
+++ b/backend/src/controllers/admin/categoriesController.ts
@@ -1,0 +1,45 @@
+/**
+ * controllers/admin/categoriesController.ts
+ * Controlador CRUD para el dominio de categorías.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as categoriesService from '../../services/categoriesService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+import { CreateCategoryDTO, UpdateCategoryDTO } from '../../models/Category';
+
+export async function index(_req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const categories = await categoriesService.getAllCategories();
+    sendSuccess(res, categories);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const category = await categoriesService.getCategoryById(req.params.id);
+    sendSuccess(res, category);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const category = await categoriesService.createCategory(req.body as CreateCategoryDTO);
+    sendSuccess(res, category, 201, 'Categoría creada');
+  } catch (err) { next(err); }
+}
+
+export async function update(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const category = await categoriesService.updateCategory(req.params.id, req.body as UpdateCategoryDTO);
+    sendSuccess(res, category, 200, 'Categoría actualizada');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await categoriesService.deleteCategory(req.params.id);
+    sendSuccess(res, null, 200, 'Categoría eliminada');
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/admin/ordersController.ts
+++ b/backend/src/controllers/admin/ordersController.ts
@@ -1,0 +1,45 @@
+/**
+ * controllers/admin/ordersController.ts
+ * Controlador CRUD para el dominio de pedidos.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as ordersService from '../../services/ordersService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+import { CreateOrderDTO, UpdateOrderDTO } from '../../models/Order';
+
+export async function index(_req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const orders = await ordersService.getAllOrders();
+    sendSuccess(res, orders);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const order = await ordersService.getOrderById(req.params.id);
+    sendSuccess(res, order);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const order = await ordersService.createOrder(req.body as CreateOrderDTO);
+    sendSuccess(res, order, 201, 'Pedido creado');
+  } catch (err) { next(err); }
+}
+
+export async function update(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const order = await ordersService.updateOrder(req.params.id, req.body as UpdateOrderDTO);
+    sendSuccess(res, order, 200, 'Pedido actualizado');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await ordersService.deleteOrder(req.params.id);
+    sendSuccess(res, null, 200, 'Pedido eliminado');
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/admin/productImagesController.ts
+++ b/backend/src/controllers/admin/productImagesController.ts
@@ -1,0 +1,47 @@
+/**
+ * controllers/admin/productImagesController.ts
+ * Controlador CRUD para imágenes de producto.
+ * Subdominio de products.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as imagesService from '../../services/productImagesService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+import { CreateProductImageDTO, UpdateProductImageDTO } from '../../models/ProductImage';
+
+export async function index(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const images = await imagesService.getImagesByProduct(req.params.productId);
+    sendSuccess(res, images);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const image = await imagesService.getImageById(req.params.id);
+    sendSuccess(res, image);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const dto: CreateProductImageDTO = { ...req.body, productId: req.params.productId };
+    const image = await imagesService.createImage(dto);
+    sendSuccess(res, image, 201, 'Imagen creada');
+  } catch (err) { next(err); }
+}
+
+export async function update(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const image = await imagesService.updateImage(req.params.id, req.body as UpdateProductImageDTO);
+    sendSuccess(res, image, 200, 'Imagen actualizada');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await imagesService.deleteImage(req.params.id);
+    sendSuccess(res, null, 200, 'Imagen eliminada');
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/admin/productVariantsController.ts
+++ b/backend/src/controllers/admin/productVariantsController.ts
@@ -1,0 +1,47 @@
+/**
+ * controllers/admin/productVariantsController.ts
+ * Controlador CRUD para variantes de producto.
+ * Subdominio de products.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as variantsService from '../../services/productVariantsService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+import { CreateProductVariantDTO, UpdateProductVariantDTO } from '../../models/ProductVariant';
+
+export async function index(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const variants = await variantsService.getVariantsByProduct(req.params.productId);
+    sendSuccess(res, variants);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const variant = await variantsService.getVariantById(req.params.id);
+    sendSuccess(res, variant);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const dto: CreateProductVariantDTO = { ...req.body, productId: req.params.productId };
+    const variant = await variantsService.createVariant(dto);
+    sendSuccess(res, variant, 201, 'Variante creada');
+  } catch (err) { next(err); }
+}
+
+export async function update(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const variant = await variantsService.updateVariant(req.params.id, req.body as UpdateProductVariantDTO);
+    sendSuccess(res, variant, 200, 'Variante actualizada');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await variantsService.deleteVariant(req.params.id);
+    sendSuccess(res, null, 200, 'Variante eliminada');
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/admin/productsController.ts
+++ b/backend/src/controllers/admin/productsController.ts
@@ -1,0 +1,45 @@
+/**
+ * controllers/admin/productsController.ts
+ * Controlador CRUD para el dominio de productos.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as productsService from '../../services/productsService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+import { CreateProductDTO, UpdateProductDTO } from '../../models/Product';
+
+export async function index(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const products = await productsService.getAllProducts();
+    sendSuccess(res, products);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const product = await productsService.getProductById(req.params.id);
+    sendSuccess(res, product);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const product = await productsService.createProduct(req.body as CreateProductDTO);
+    sendSuccess(res, product, 201, 'Producto creado');
+  } catch (err) { next(err); }
+}
+
+export async function update(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const product = await productsService.updateProduct(req.params.id, req.body as UpdateProductDTO);
+    sendSuccess(res, product, 200, 'Producto actualizado');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await productsService.deleteProduct(req.params.id);
+    sendSuccess(res, null, 200, 'Producto eliminado');
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/admin/usersController.ts
+++ b/backend/src/controllers/admin/usersController.ts
@@ -1,0 +1,37 @@
+/**
+ * controllers/admin/usersController.ts
+ * Controlador CRUD para el módulo de usuarios.
+ */
+
+import { Response, NextFunction } from 'express';
+import * as usersService from '../../services/usersService';
+import { sendSuccess } from '../../utils/response';
+import { AuthenticatedRequest } from '../../types';
+
+export async function index(_req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const users = await usersService.getAllUsers();
+    sendSuccess(res, users);
+  } catch (err) { next(err); }
+}
+
+export async function show(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const user = await usersService.getUserById(req.params.id);
+    sendSuccess(res, user);
+  } catch (err) { next(err); }
+}
+
+export async function create(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const user = await usersService.createUser(req.body);
+    sendSuccess(res, user, 201, 'Usuario creado');
+  } catch (err) { next(err); }
+}
+
+export async function remove(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await usersService.deleteUser(req.params.id);
+    sendSuccess(res, null, 200, 'Usuario eliminado');
+  } catch (err) { next(err); }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * index.ts
+ * Punto de entrada del servidor.
+ * Se encarga únicamente de iniciar el servidor con la app configurada.
+ */
+
+import 'dotenv/config';
+import app from './app';
+import { env } from './config/env';
+import { connectDB } from './config/database';
+
+async function bootstrap(): Promise<void> {
+  await connectDB();
+
+  app.listen(env.PORT, () => {
+    console.log(`[Server] Escuchando en http://localhost:${env.PORT}`);
+    console.log(`[Server] Modo: ${env.NODE_ENV}`);
+  });
+}
+
+bootstrap().catch((err) => {
+  console.error('[Server] Error al iniciar:', err);
+  process.exit(1);
+});

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,0 +1,32 @@
+/**
+ * middlewares/auth.ts
+ * Middleware de autenticación JWT para rutas protegidas.
+ * Valida el token y adjunta el payload en req.admin.
+ */
+
+import { Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { env } from '../config/env';
+import { JwtPayload, AuthenticatedRequest } from '../types';
+
+export function authMiddleware(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    res.status(401).json({ success: false, message: 'Token requerido' });
+    return;
+  }
+
+  try {
+    const decoded = jwt.verify(token, env.JWT_SECRET) as JwtPayload;
+    req.admin = decoded;
+    next();
+  } catch {
+    res.status(401).json({ success: false, message: 'Token inválido o expirado' });
+  }
+}

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,0 +1,39 @@
+/**
+ * middlewares/errorHandler.ts
+ * Middleware global de manejo de errores.
+ * Debe registrarse ÚLTIMO en la cadena de middlewares de Express.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+export interface AppError extends Error {
+  statusCode?: number;
+  errors?: string[];
+}
+
+export function errorHandler(
+  err: AppError,
+  _req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
+): void {
+  const statusCode = err.statusCode ?? 500;
+  const message = err.message || 'Error interno del servidor';
+
+  console.error(`[ERROR] ${statusCode} - ${message}`, err.stack);
+
+  res.status(statusCode).json({
+    success: false,
+    message,
+    ...(err.errors ? { errors: err.errors } : {}),
+  });
+}
+
+/** Helper para crear errores con código HTTP */
+export function createError(message: string, statusCode = 500, errors?: string[]): AppError {
+  const error: AppError = new Error(message);
+  error.statusCode = statusCode;
+  if (errors) error.errors = errors;
+  return error;
+}

--- a/backend/src/middlewares/permissions.ts
+++ b/backend/src/middlewares/permissions.ts
@@ -1,0 +1,27 @@
+/**
+ * middlewares/permissions.ts
+ * Factory de middleware de autorización por roles.
+ * Uso: requireRole(UserRole.ADMIN) en los router.
+ */
+
+import { Response, NextFunction } from 'express';
+import { UserRole, AuthenticatedRequest } from '../types';
+
+/**
+ * Retorna un middleware que verifica que el usuario tenga
+ * al menos uno de los roles indicados.
+ */
+export function requireRole(...roles: UserRole[]) {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    const userRole = req.admin?.role as UserRole | undefined;
+
+    if (!userRole || !roles.includes(userRole)) {
+      res.status(403).json({
+        success: false,
+        message: 'Acceso denegado: permisos insuficientes',
+      });
+      return;
+    }
+    next();
+  };
+}

--- a/backend/src/models/Category.ts
+++ b/backend/src/models/Category.ts
@@ -1,0 +1,18 @@
+/**
+ * models/Category.ts
+ * Modelo de datos para las categorías de productos.
+ */
+
+export interface Category {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  imageUrl?: string;
+  parentId?: string; // Para categorías anidadas (árbol de categorías ERP)
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateCategoryDTO = Omit<Category, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateCategoryDTO = Partial<CreateCategoryDTO>;

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -1,0 +1,21 @@
+/**
+ * models/Order.ts
+ * Modelo de pedido / venta.
+ */
+
+import { OrderStatus } from '../types';
+
+export interface Order {
+  id: string;
+  customerName: string;
+  customerPhone: string;
+  customerEmail?: string;
+  status: OrderStatus;
+  total: number;
+  notes?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateOrderDTO = Omit<Order, 'id' | 'status' | 'createdAt' | 'updatedAt'>;
+export type UpdateOrderDTO = Partial<Omit<Order, 'id' | 'createdAt' | 'updatedAt'>>;

--- a/backend/src/models/OrderItem.ts
+++ b/backend/src/models/OrderItem.ts
@@ -1,0 +1,17 @@
+/**
+ * models/OrderItem.ts
+ * Ítem (línea) dentro de un pedido.
+ */
+
+export interface OrderItem {
+  id: string;
+  orderId: string;
+  productId: string;
+  productVariantId?: string;
+  productName: string; // Snapshot del nombre al momento de la venta
+  unitPrice: number;   // Snapshot del precio al momento de la venta
+  quantity: number;
+  subtotal: number;
+}
+
+export type CreateOrderItemDTO = Omit<OrderItem, 'id'>;

--- a/backend/src/models/Product.ts
+++ b/backend/src/models/Product.ts
@@ -1,0 +1,26 @@
+/**
+ * models/Product.ts
+ * Modelo de datos del producto base.
+ * Las variantes (talle, color, etc.) se gestionan en ProductVariant.
+ * Las imágenes en ProductImage.
+ */
+
+import { ProductStatus } from '../types';
+
+export interface Product {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  price: number;
+  compareAtPrice?: number;  // Precio tachado / precio original
+  categoryId: string;
+  status: ProductStatus;
+  sku?: string;
+  stock: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateProductDTO = Omit<Product, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateProductDTO = Partial<CreateProductDTO>;

--- a/backend/src/models/ProductImage.ts
+++ b/backend/src/models/ProductImage.ts
@@ -1,0 +1,18 @@
+/**
+ * models/ProductImage.ts
+ * Imágenes asociadas a un producto.
+ * Subdominio de products.
+ */
+
+export interface ProductImage {
+  id: string;
+  productId: string;
+  url: string;
+  altText?: string;
+  position: number; // Orden de visualización
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateProductImageDTO = Omit<ProductImage, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateProductImageDTO = Partial<CreateProductImageDTO>;

--- a/backend/src/models/ProductVariant.ts
+++ b/backend/src/models/ProductVariant.ts
@@ -1,0 +1,20 @@
+/**
+ * models/ProductVariant.ts
+ * Variante de producto: combinación de atributos (color, talle, material, etc.)
+ * Subdominio de products.
+ */
+
+export interface ProductVariant {
+  id: string;
+  productId: string;
+  sku: string;
+  attributes: Record<string, string>; // { color: 'rojo', talle: 'M' }
+  price?: number;                      // Si difiere del precio base
+  stock: number;
+  imageUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateProductVariantDTO = Omit<ProductVariant, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateProductVariantDTO = Partial<CreateProductVariantDTO>;

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -1,0 +1,23 @@
+/**
+ * models/User.ts
+ * Modelo de datos del usuario / administrador del sistema.
+ * Cuando se integre una BD, este modelo se convierte en esquema ORM/ODM.
+ */
+
+import { UserRole } from '../types';
+
+export interface User {
+  id: string;
+  username: string;
+  passwordHash: string;
+  role: UserRole;
+  email?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Datos para crear un usuario (sin id ni fechas, generadas por el sistema) */
+export type CreateUserDTO = Omit<User, 'id' | 'createdAt' | 'updatedAt'>;
+
+/** Datos públicos de usuario (sin hash de contraseña) */
+export type PublicUser = Omit<User, 'passwordHash'>;

--- a/backend/src/routes/admin/auth.ts
+++ b/backend/src/routes/admin/auth.ts
@@ -1,0 +1,14 @@
+/**
+ * routes/admin/auth.ts
+ * Rutas de autenticación del panel de administración.
+ * POST /api/admin/auth/login
+ */
+
+import { Router } from 'express';
+import { loginController } from '../../controllers/admin/authController';
+
+const router = Router();
+
+router.post('/login', loginController);
+
+export default router;

--- a/backend/src/routes/admin/categories.ts
+++ b/backend/src/routes/admin/categories.ts
@@ -1,0 +1,24 @@
+/**
+ * routes/admin/categories.ts
+ * Rutas del dominio de categorías.
+ *
+ * Prefijo: /api/admin/categories
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../controllers/admin/categoriesController';
+import { authMiddleware } from '../../middlewares/auth';
+import { requireRole } from '../../middlewares/permissions';
+import { UserRole } from '../../types';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get('/',    requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.index);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.show);
+router.post('/',   requireRole(UserRole.ADMIN), ctrl.create);
+router.put('/:id', requireRole(UserRole.ADMIN), ctrl.update);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.remove);
+
+export default router;

--- a/backend/src/routes/admin/orders.ts
+++ b/backend/src/routes/admin/orders.ts
@@ -1,0 +1,24 @@
+/**
+ * routes/admin/orders.ts
+ * Rutas del dominio de pedidos.
+ *
+ * Prefijo: /api/admin/orders
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../controllers/admin/ordersController';
+import { authMiddleware } from '../../middlewares/auth';
+import { requireRole } from '../../middlewares/permissions';
+import { UserRole } from '../../types';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.get('/',    requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.index);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.show);
+router.post('/',   requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.create);
+router.put('/:id', requireRole(UserRole.ADMIN), ctrl.update);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.remove);
+
+export default router;

--- a/backend/src/routes/admin/products.ts
+++ b/backend/src/routes/admin/products.ts
@@ -1,0 +1,32 @@
+/**
+ * routes/admin/products.ts
+ * Rutas principales del dominio de productos.
+ * Monta subdominios: /variants y /images.
+ *
+ * Prefijo: /api/admin/products
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../controllers/admin/productsController';
+import { authMiddleware } from '../../middlewares/auth';
+import { requireRole } from '../../middlewares/permissions';
+import { UserRole } from '../../types';
+import variantsRouter from './products/variants';
+import imagesRouter from './products/images';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+// ─── Subdominios ──────────────────────────────────────────────────────────────
+router.use('/:productId/variants', variantsRouter);
+router.use('/:productId/images',   imagesRouter);
+
+// ─── CRUD productos ───────────────────────────────────────────────────────────
+router.get('/',    requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.index);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.show);
+router.post('/',   requireRole(UserRole.ADMIN), ctrl.create);
+router.put('/:id', requireRole(UserRole.ADMIN), ctrl.update);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.remove);
+
+export default router;

--- a/backend/src/routes/admin/products/images.ts
+++ b/backend/src/routes/admin/products/images.ts
@@ -1,0 +1,24 @@
+/**
+ * routes/admin/products/images.ts
+ * Rutas de imágenes de producto (subdominio de products).
+ *
+ * Prefijo: /api/admin/products/:productId/images
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../../controllers/admin/productImagesController';
+import { authMiddleware } from '../../../middlewares/auth';
+import { requireRole } from '../../../middlewares/permissions';
+import { UserRole } from '../../../types';
+
+const router = Router({ mergeParams: true }); // mergeParams para acceder a :productId
+
+router.use(authMiddleware);
+
+router.get('/',    requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.index);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.show);
+router.post('/',   requireRole(UserRole.ADMIN), ctrl.create);
+router.put('/:id', requireRole(UserRole.ADMIN), ctrl.update);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.remove);
+
+export default router;

--- a/backend/src/routes/admin/products/variants.ts
+++ b/backend/src/routes/admin/products/variants.ts
@@ -1,0 +1,24 @@
+/**
+ * routes/admin/products/variants.ts
+ * Rutas de variantes de producto (subdominio de products).
+ *
+ * Prefijo: /api/admin/products/:productId/variants
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../../controllers/admin/productVariantsController';
+import { authMiddleware } from '../../../middlewares/auth';
+import { requireRole } from '../../../middlewares/permissions';
+import { UserRole } from '../../../types';
+
+const router = Router({ mergeParams: true }); // mergeParams para acceder a :productId
+
+router.use(authMiddleware);
+
+router.get('/',    requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.index);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.show);
+router.post('/',   requireRole(UserRole.ADMIN), ctrl.create);
+router.put('/:id', requireRole(UserRole.ADMIN), ctrl.update);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.remove);
+
+export default router;

--- a/backend/src/routes/admin/users.ts
+++ b/backend/src/routes/admin/users.ts
@@ -1,0 +1,24 @@
+/**
+ * routes/admin/users.ts
+ * Rutas del módulo de usuarios (solo admins).
+ *
+ * Prefijo: /api/admin/users
+ */
+
+import { Router } from 'express';
+import * as ctrl from '../../controllers/admin/usersController';
+import { authMiddleware } from '../../middlewares/auth';
+import { requireRole } from '../../middlewares/permissions';
+import { UserRole } from '../../types';
+
+const router = Router();
+
+router.use(authMiddleware);
+router.use(requireRole(UserRole.ADMIN)); // Sólo admin puede gestionar usuarios
+
+router.get('/',    ctrl.index);
+router.get('/:id', ctrl.show);
+router.post('/',   ctrl.create);
+router.delete('/:id', ctrl.remove);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,28 @@
+/**
+ * routes/index.ts
+ * Router raíz que monta todos los sub-routers de la API.
+ * Para agregar un nuevo dominio:
+ *   1. Crea src/routes/admin/miDominio.ts
+ *   2. Importa y monta aquí: adminRouter.use('/mi-dominio', miDominioRouter)
+ */
+
+import { Router } from 'express';
+import authRouter      from './admin/auth';
+import productsRouter  from './admin/products';
+import categoriesRouter from './admin/categories';
+import ordersRouter    from './admin/orders';
+import usersRouter     from './admin/users';
+
+const adminRouter = Router();
+
+adminRouter.use('/auth',       authRouter);
+adminRouter.use('/products',   productsRouter);
+adminRouter.use('/categories', categoriesRouter);
+adminRouter.use('/orders',     ordersRouter);
+adminRouter.use('/users',      usersRouter);
+
+// Router principal de la API
+const apiRouter = Router();
+apiRouter.use('/admin', adminRouter);
+
+export default apiRouter;

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,0 +1,38 @@
+/**
+ * services/authService.ts
+ * Lógica de negocio para autenticación de administradores.
+ * Actualmente usa usuarios en memoria; migrar a BD cuando esté disponible.
+ */
+
+import { env } from '../config/env';
+import { comparePassword } from '../utils/bcrypt';
+import { signToken } from '../utils/jwt';
+import { UserRole } from '../types';
+
+interface InMemoryUser {
+  user: string;
+  hash: string;
+  role: UserRole;
+}
+
+// En memoria hasta integrar BD
+const USERS: InMemoryUser[] = [
+  { user: env.ADMIN_USER,  hash: env.ADMIN_HASH,  role: UserRole.ADMIN  },
+  { user: env.EDITOR_USER, hash: env.EDITOR_HASH, role: UserRole.EDITOR },
+];
+
+export interface LoginResult {
+  token: string;
+  role: UserRole;
+}
+
+export async function login(username: string, password: string): Promise<LoginResult> {
+  const found = USERS.find(u => u.user === username);
+  if (!found) throw Object.assign(new Error('Usuario inválido'), { statusCode: 401 });
+
+  const valid = await comparePassword(password, found.hash);
+  if (!valid) throw Object.assign(new Error('Contraseña incorrecta'), { statusCode: 401 });
+
+  const token = signToken({ user: found.user, role: found.role });
+  return { token, role: found.role };
+}

--- a/backend/src/services/categoriesService.ts
+++ b/backend/src/services/categoriesService.ts
@@ -1,0 +1,39 @@
+/**
+ * services/categoriesService.ts
+ * Lógica de negocio para el dominio de categorías.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Category, CreateCategoryDTO, UpdateCategoryDTO } from '../models/Category';
+import { createError } from '../middlewares/errorHandler';
+
+const store: Map<string, Category> = new Map();
+
+export async function getAllCategories(): Promise<Category[]> {
+  return Array.from(store.values());
+}
+
+export async function getCategoryById(id: string): Promise<Category> {
+  const category = store.get(id);
+  if (!category) throw createError('Categoría no encontrada', 404);
+  return category;
+}
+
+export async function createCategory(dto: CreateCategoryDTO): Promise<Category> {
+  const now = new Date();
+  const category: Category = { ...dto, id: uuidv4(), createdAt: now, updatedAt: now };
+  store.set(category.id, category);
+  return category;
+}
+
+export async function updateCategory(id: string, dto: UpdateCategoryDTO): Promise<Category> {
+  const existing = await getCategoryById(id);
+  const updated: Category = { ...existing, ...dto, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}
+
+export async function deleteCategory(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Categoría no encontrada', 404);
+  store.delete(id);
+}

--- a/backend/src/services/ordersService.ts
+++ b/backend/src/services/ordersService.ts
@@ -1,0 +1,46 @@
+/**
+ * services/ordersService.ts
+ * Lógica de negocio para el dominio de pedidos.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Order, CreateOrderDTO, UpdateOrderDTO } from '../models/Order';
+import { OrderStatus } from '../types';
+import { createError } from '../middlewares/errorHandler';
+
+const store: Map<string, Order> = new Map();
+
+export async function getAllOrders(): Promise<Order[]> {
+  return Array.from(store.values());
+}
+
+export async function getOrderById(id: string): Promise<Order> {
+  const order = store.get(id);
+  if (!order) throw createError('Pedido no encontrado', 404);
+  return order;
+}
+
+export async function createOrder(dto: CreateOrderDTO): Promise<Order> {
+  const now = new Date();
+  const order: Order = {
+    ...dto,
+    id: uuidv4(),
+    status: OrderStatus.PENDING,
+    createdAt: now,
+    updatedAt: now,
+  };
+  store.set(order.id, order);
+  return order;
+}
+
+export async function updateOrder(id: string, dto: UpdateOrderDTO): Promise<Order> {
+  const existing = await getOrderById(id);
+  const updated: Order = { ...existing, ...dto, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}
+
+export async function deleteOrder(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Pedido no encontrado', 404);
+  store.delete(id);
+}

--- a/backend/src/services/productImagesService.ts
+++ b/backend/src/services/productImagesService.ts
@@ -1,0 +1,42 @@
+/**
+ * services/productImagesService.ts
+ * Lógica de negocio para imágenes de producto.
+ * Subdominio de products.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { ProductImage, CreateProductImageDTO, UpdateProductImageDTO } from '../models/ProductImage';
+import { createError } from '../middlewares/errorHandler';
+
+const store: Map<string, ProductImage> = new Map();
+
+export async function getImagesByProduct(productId: string): Promise<ProductImage[]> {
+  return Array.from(store.values())
+    .filter(img => img.productId === productId)
+    .sort((a, b) => a.position - b.position);
+}
+
+export async function getImageById(id: string): Promise<ProductImage> {
+  const image = store.get(id);
+  if (!image) throw createError('Imagen no encontrada', 404);
+  return image;
+}
+
+export async function createImage(dto: CreateProductImageDTO): Promise<ProductImage> {
+  const now = new Date();
+  const image: ProductImage = { ...dto, id: uuidv4(), createdAt: now, updatedAt: now };
+  store.set(image.id, image);
+  return image;
+}
+
+export async function updateImage(id: string, dto: UpdateProductImageDTO): Promise<ProductImage> {
+  const existing = await getImageById(id);
+  const updated: ProductImage = { ...existing, ...dto, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}
+
+export async function deleteImage(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Imagen no encontrada', 404);
+  store.delete(id);
+}

--- a/backend/src/services/productVariantsService.ts
+++ b/backend/src/services/productVariantsService.ts
@@ -1,0 +1,40 @@
+/**
+ * services/productVariantsService.ts
+ * Lógica de negocio para variantes de producto.
+ * Subdominio de products.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { ProductVariant, CreateProductVariantDTO, UpdateProductVariantDTO } from '../models/ProductVariant';
+import { createError } from '../middlewares/errorHandler';
+
+const store: Map<string, ProductVariant> = new Map();
+
+export async function getVariantsByProduct(productId: string): Promise<ProductVariant[]> {
+  return Array.from(store.values()).filter(v => v.productId === productId);
+}
+
+export async function getVariantById(id: string): Promise<ProductVariant> {
+  const variant = store.get(id);
+  if (!variant) throw createError('Variante no encontrada', 404);
+  return variant;
+}
+
+export async function createVariant(dto: CreateProductVariantDTO): Promise<ProductVariant> {
+  const now = new Date();
+  const variant: ProductVariant = { ...dto, id: uuidv4(), createdAt: now, updatedAt: now };
+  store.set(variant.id, variant);
+  return variant;
+}
+
+export async function updateVariant(id: string, dto: UpdateProductVariantDTO): Promise<ProductVariant> {
+  const existing = await getVariantById(id);
+  const updated: ProductVariant = { ...existing, ...dto, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}
+
+export async function deleteVariant(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Variante no encontrada', 404);
+  store.delete(id);
+}

--- a/backend/src/services/productsService.ts
+++ b/backend/src/services/productsService.ts
@@ -1,0 +1,48 @@
+/**
+ * services/productsService.ts
+ * Lógica de negocio para el dominio de productos.
+ * Actualmente usa un store en memoria; sustituir por llamadas a BD.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Product, CreateProductDTO, UpdateProductDTO } from '../models/Product';
+import { ProductStatus } from '../types';
+import { createError } from '../middlewares/errorHandler';
+
+// Store in-memory (reemplazar con repositorio de BD)
+const store: Map<string, Product> = new Map();
+
+export async function getAllProducts(): Promise<Product[]> {
+  return Array.from(store.values());
+}
+
+export async function getProductById(id: string): Promise<Product> {
+  const product = store.get(id);
+  if (!product) throw createError('Producto no encontrado', 404);
+  return product;
+}
+
+export async function createProduct(dto: CreateProductDTO): Promise<Product> {
+  const now = new Date();
+  const product: Product = {
+    ...dto,
+    id: uuidv4(),
+    status: dto.status ?? ProductStatus.DRAFT,
+    createdAt: now,
+    updatedAt: now,
+  };
+  store.set(product.id, product);
+  return product;
+}
+
+export async function updateProduct(id: string, dto: UpdateProductDTO): Promise<Product> {
+  const existing = await getProductById(id);
+  const updated: Product = { ...existing, ...dto, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}
+
+export async function deleteProduct(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Producto no encontrado', 404);
+  store.delete(id);
+}

--- a/backend/src/services/usersService.ts
+++ b/backend/src/services/usersService.ts
@@ -1,0 +1,38 @@
+/**
+ * services/usersService.ts
+ * Lógica de negocio para el módulo de usuarios.
+ * Preparado para cuando se integre una base de datos.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { User, CreateUserDTO, PublicUser } from '../models/User';
+import { hashPassword } from '../utils/bcrypt';
+import { createError } from '../middlewares/errorHandler';
+
+const store: Map<string, User> = new Map();
+
+export async function getAllUsers(): Promise<PublicUser[]> {
+  return Array.from(store.values()).map(({ passwordHash: _, ...rest }) => rest);
+}
+
+export async function getUserById(id: string): Promise<PublicUser> {
+  const user = store.get(id);
+  if (!user) throw createError('Usuario no encontrado', 404);
+  const { passwordHash: _, ...rest } = user;
+  return rest;
+}
+
+export async function createUser(dto: Omit<CreateUserDTO, 'passwordHash'> & { password: string }): Promise<PublicUser> {
+  const { password, ...rest } = dto;
+  const passwordHash = await hashPassword(password);
+  const now = new Date();
+  const user: User = { ...rest, passwordHash, id: uuidv4(), createdAt: now, updatedAt: now };
+  store.set(user.id, user);
+  const { passwordHash: _, ...publicUser } = user;
+  return publicUser;
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  if (!store.has(id)) throw createError('Usuario no encontrado', 404);
+  store.delete(id);
+}

--- a/backend/src/types/enums.ts
+++ b/backend/src/types/enums.ts
@@ -1,0 +1,32 @@
+/**
+ * types/enums.ts
+ * Enumeraciones globales compartidas entre módulos.
+ * Agregar nuevas a medida que crezca el proyecto.
+ */
+
+export enum UserRole {
+  ADMIN = 'admin',
+  EDITOR = 'editor',
+  VIEWER = 'viewer',
+}
+
+export enum OrderStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  SHIPPED = 'shipped',
+  DELIVERED = 'delivered',
+  CANCELLED = 'cancelled',
+}
+
+export enum ProductStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  DRAFT = 'draft',
+  ARCHIVED = 'archived',
+}
+
+export enum StockMovementType {
+  IN = 'in',
+  OUT = 'out',
+  ADJUSTMENT = 'adjustment',
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,42 @@
+/**
+ * types/index.ts
+ * Tipos globales reutilizables en toda la aplicación.
+ * Re-exporta también los enums para facilitar imports.
+ */
+
+export * from './enums';
+
+// ─── Payload JWT ──────────────────────────────────────────────────────────────
+export interface JwtPayload {
+  user: string;
+  role: string;
+  iat?: number;
+  exp?: number;
+}
+
+// ─── Respuesta estándar de la API ─────────────────────────────────────────────
+export interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  message?: string;
+  errors?: string[];
+}
+
+// ─── Paginación ───────────────────────────────────────────────────────────────
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+  meta: PaginationMeta;
+}
+
+// ─── Extensión de Express Request ─────────────────────────────────────────────
+import { Request } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  admin?: JwtPayload;
+}

--- a/backend/src/utils/bcrypt.ts
+++ b/backend/src/utils/bcrypt.ts
@@ -1,0 +1,16 @@
+/**
+ * utils/bcrypt.ts
+ * Helpers para hashear y comparar contraseñas con bcrypt.
+ */
+
+import bcrypt from 'bcryptjs';
+
+const SALT_ROUNDS = 10;
+
+export async function hashPassword(plainPassword: string): Promise<string> {
+  return bcrypt.hash(plainPassword, SALT_ROUNDS);
+}
+
+export async function comparePassword(plainPassword: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(plainPassword, hash);
+}

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -1,0 +1,16 @@
+/**
+ * utils/jwt.ts
+ * Helpers para firmar y verificar tokens JWT.
+ */
+
+import jwt from 'jsonwebtoken';
+import { env } from '../config/env';
+import { JwtPayload } from '../types';
+
+export function signToken(payload: Omit<JwtPayload, 'iat' | 'exp'>, expiresIn = '2h'): string {
+  return jwt.sign(payload, env.JWT_SECRET, { expiresIn } as jwt.SignOptions);
+}
+
+export function verifyToken(token: string): JwtPayload {
+  return jwt.verify(token, env.JWT_SECRET) as JwtPayload;
+}

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -1,0 +1,28 @@
+/**
+ * utils/response.ts
+ * Helpers para construir respuestas HTTP estandarizadas.
+ * Garantiza un formato consistente en toda la API.
+ */
+
+import { Response } from 'express';
+import { ApiResponse, PaginationMeta, PaginatedResponse } from '../types';
+
+export function sendSuccess<T>(res: Response, data: T, statusCode = 200, message?: string): void {
+  const body: ApiResponse<T> = { success: true, data, ...(message ? { message } : {}) };
+  res.status(statusCode).json(body);
+}
+
+export function sendError(res: Response, message: string, statusCode = 400, errors?: string[]): void {
+  const body: ApiResponse = { success: false, message, ...(errors ? { errors } : {}) };
+  res.status(statusCode).json(body);
+}
+
+export function sendPaginated<T>(
+  res: Response,
+  data: T[],
+  meta: PaginationMeta,
+  statusCode = 200,
+): void {
+  const body: PaginatedResponse<T> = { success: true, data, meta };
+  res.status(statusCode).json(body);
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Estructura ERP-ready creada
Edited
.env+3-2
Puntos clave de la arquitectura
Separación de responsabilidades: servicios sin Express, controladores delgados, rutas declarativas Subdominios anidados: products/:id/variants y products/:id/images con mergeParams: true Control de acceso por roles: middleware requireRole(UserRole.ADMIN, UserRole.EDITOR) reutilizable Respuestas estándar: sendSuccess / sendError / sendPaginated garantizan formato consistente Escalabilidad: agregar un dominio = 4 pasos (model → service → controller → route + montaje en routes/index.ts) Build verificado: tsc --noEmit sin errores, servidor arranca y login retorna JWT correctamente El README.md documenta la filosofía, estructura completa y ejemplos paso a paso para agregar dominios y subdominios.