### PR TITLE
El servidor:

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,14 +23,9 @@ ADMIN_HASH=$2b$10$XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 EDITOR_USER=editor
 EDITOR_HASH=$2b$10$XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# ─── Base de datos (descomentar cuando se integre) ────────────────────────────
-# Selecciona UNA según el motor elegido:
-
-# PostgreSQL (con pg / Prisma / TypeORM)
-# DATABASE_URL=postgresql://usuario:password@localhost:5432/allmart_db
-
-# MongoDB (con Mongoose)
-# DATABASE_URL=mongodb://localhost:27017/allmart_db
-
-# MySQL / MariaDB
-# DATABASE_URL=mysql://usuario:password@localhost:3306/allmart_db
+# ─── PostgreSQL ────────────────────────────────────────────────────────
+DB_HOST=localhost         # Host del servidor PostgreSQL
+DB_PORT=5432              # Puerto (por defecto 5432)
+DB_USER=postgres          # Usuario de la base de datos
+DB_PASSWORD=tu_password   # Contraseña del usuario
+DB_NAME=allmart_db        # Nombre de la base de datos

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^17.3.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.3",
+        "pg": "^8.18.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -21,6 +22,7 @@
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^20.14.0",
+        "@types/pg": "^8.16.0",
         "@types/uuid": "^9.0.8",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
@@ -199,6 +201,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1356,6 +1370,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1367,6 +1470,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1651,6 +1793,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1909,7 +2060,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^17.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.3",
+    "pg": "^8.18.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^20.14.0",
+    "@types/pg": "^8.16.0",
     "@types/uuid": "^9.0.8",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,17 +1,25 @@
 /**
  * config/database.ts
- * Punto de conexión a la base de datos.
- * Actualmente el sistema usa datos en memoria; cuando se integre
- * una BD (PostgreSQL, MongoDB, etc.) la lógica de conexión va aquí.
+ * Inicializa y verifica la conexión al pool de PostgreSQL.
+ * Llamado una sola vez desde index.ts al arrancar el servidor.
  *
- * Ejemplo con PostgreSQL (pg / prisma / typeorm):
- *   export const db = new Pool({ connectionString: env.DATABASE_URL });
- *
- * Ejemplo con MongoDB (mongoose):
- *   export const connectDB = async () => mongoose.connect(env.DATABASE_URL);
+ * El pool en sí vive en config/db.ts y se importa directamente
+ * en los servicios/repositorios que lo necesiten.
  */
 
+import { pool } from './db';
+
 export const connectDB = async (): Promise<void> => {
-  // TODO: implementar conexión cuando se elija la BD
-  console.log('[DB] Base de datos en modo in-memory (sin conexión externa)');
+  let client;
+  try {
+    client = await pool.connect();
+    const result = await client.query('SELECT NOW() AS now');
+    console.log(`[DB] Conexión a PostgreSQL exitosa — servidor: ${result.rows[0].now}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[DB] No se pudo conectar a PostgreSQL: ${message}`);
+    throw err; // Propaga para que bootstrap() llame a process.exit(1)
+  } finally {
+    client?.release();
+  }
 };

--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -1,0 +1,32 @@
+/**
+ * config/db.ts
+ * Pool de conexiones a PostgreSQL usando `pg` (node-postgres).
+ * Exporta el pool como singleton reutilizable en servicios y repositorios.
+ *
+ * Uso:
+ *   import { pool } from '../config/db';
+ *   const { rows } = await pool.query('SELECT * FROM users WHERE id = $1', [id]);
+ */
+
+import { Pool, PoolConfig } from 'pg';
+import { env } from './env';
+
+const poolConfig: PoolConfig = {
+  host:     env.DB_HOST,
+  port:     env.DB_PORT,
+  user:     env.DB_USER,
+  password: env.DB_PASSWORD,
+  database: env.DB_NAME,
+
+  // ─── Configuración del pool ──────────────────────────────────────────────
+  max:              10,    // Máximo de conexiones simultáneas
+  idleTimeoutMillis: 30_000, // Cierra conexiones idle tras 30 s
+  connectionTimeoutMillis: 5_000, // Timeout para obtener conexión del pool
+};
+
+export const pool = new Pool(poolConfig);
+
+// Loguear warnings del pool en producción
+pool.on('error', (err) => {
+  console.error('[DB] Error inesperado en cliente del pool:', err.message);
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -18,6 +18,10 @@ export const env = {
   EDITOR_USER: process.env.EDITOR_USER || 'editor',
   EDITOR_HASH: process.env.EDITOR_HASH || '$2b$10$mt.YMa6mFiMmnnxRettsAO/brFQfx1rJQBWFN.HePpYNYtoj7ZRhu',
 
-  // Database — cuando se conecte una BD real, agregar aquí
-  // DATABASE_URL: process.env.DATABASE_URL || '',
+  // ─── PostgreSQL ───────────────────────────────────────────────────────────
+  DB_HOST:     process.env.DB_HOST     || 'localhost',
+  DB_PORT:     parseInt(process.env.DB_PORT || '5432', 10),
+  DB_USER:     process.env.DB_USER     || 'postgres',
+  DB_PASSWORD: process.env.DB_PASSWORD || '',
+  DB_NAME:     process.env.DB_NAME     || 'allmart_db',
 } as const;


### PR DESCRIPTION
Intenta conectar a PostgreSQL → pool.connect()
Loguea [DB] No se pudo conectar a PostgreSQL: SASL: ... → error claro ✅ Propaga el error y bootstrap() termina con process.exit(1) ✅ (El error SASL confirma que el pool sí alcanza PostgreSQL pero el DB_PASSWORD está vacío en .env — el comportamiento es exactamente el esperado.) Los servicios y repositorios importan directamente pool de src/config/db.ts para sus queries.