### PR TITLE
Scripts SQL:

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,8 +24,11 @@ EDITOR_USER=editor
 EDITOR_HASH=$2b$10$XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # ─── PostgreSQL ────────────────────────────────────────────────────────
+# Allmart usa el superusuario postgres para no crear roles adicionales
+# que puedan interferir con otros proyectos. Ver docs/DB_SETUP.md.
+# Para crear la base de datos ejecutar: psql -U postgres -f scripts/create_db.sql
 DB_HOST=localhost         # Host del servidor PostgreSQL
 DB_PORT=5432              # Puerto (por defecto 5432)
-DB_USER=postgres          # Usuario de la base de datos
-DB_PASSWORD=tu_password   # Contraseña del usuario
-DB_NAME=allmart_db        # Nombre de la base de datos
+DB_USER=postgres          # Superusuario de PostgreSQL
+DB_PASSWORD=              # Password del superusuario postgres (requerido)
+DB_NAME=allmart_db        # Nombre de la base de datos (creada por create_db.sql)

--- a/backend/README.md
+++ b/backend/README.md
@@ -156,17 +156,23 @@ npm install
 
 # 2. Configurar variables de entorno
 cp .env.example .env
-# Editar .env con los valores reales (ver sección Variables de entorno)
+# Completar DB_PASSWORD con el password del superusuario postgres
 
-# 3. Iniciar en modo desarrollo (hot-reload)
+# 3. Crear la base de datos PostgreSQL (solo la primera vez)
+sudo -u postgres psql -f scripts/create_db.sql
+# Ver docs/DB_SETUP.md para instrucciones detalladas y troubleshooting
+
+# 4. Iniciar en modo desarrollo (hot-reload)
 npm run dev
 
-# 4. O compilar y ejecutar en producción
+# 5. O compilar y ejecutar en producción
 npm run build
 npm start
 ```
 
 > El servidor queda disponible en **http://localhost:3001**
+
+> Para resetear la base de datos en desarrollo: `sudo -u postgres psql -f scripts/drop_db.sql`
 
 ### Scripts disponibles
 
@@ -191,7 +197,13 @@ Todas las variables quedan centralizadas en `src/config/env.ts`.
 | `ADMIN_HASH` | **Sí** | — | Hash bcrypt de la contraseña admin |
 | `EDITOR_USER` | No | `editor` | Nombre del usuario editor |
 | `EDITOR_HASH` | **Sí** | — | Hash bcrypt de la contraseña editor |
-| `DATABASE_URL` | No | — | URL de conexión a BD (futuro) |
+| `DB_HOST` | No | `localhost` | Host de PostgreSQL |
+| `DB_PORT` | No | `5432` | Puerto de PostgreSQL |
+| `DB_USER` | No | `postgres` | Superusuario de PostgreSQL |
+| `DB_PASSWORD` | **Sí** | — | Password del superusuario postgres |
+| `DB_NAME` | No | `allmart_db` | Nombre de la base de datos |
+
+> Ver [docs/DB\_SETUP.md](docs/DB_SETUP.md) para instrucciones detalladas de configuración de PostgreSQL.
 
 > Para generar un hash bcrypt:
 > ```bash

--- a/backend/docs/DB_SETUP.md
+++ b/backend/docs/DB_SETUP.md
@@ -1,0 +1,128 @@
+# Configuración de la base de datos PostgreSQL — Allmart
+
+> **Estrategia de acceso:** Allmart usa el superusuario `postgres` para no interferir con otros proyectos del mismo equipo. No se crea un rol adicional.
+
+---
+
+## Requisitos previos
+
+- PostgreSQL >= 14 instalado y en ejecución
+- Acceso al superusuario `postgres` (con su password)
+
+---
+
+## 1. Crear la base de datos
+
+> **Nota:** En Linux, el superusuario `postgres` usa autenticación `peer` por defecto, por lo que se debe invocar con `sudo -u postgres`.
+
+Ejecuta el script desde la raíz del backend:
+
+```bash
+sudo -u postgres psql -f scripts/create_db.sql
+```
+
+El script realiza las siguientes acciones:
+
+| Acción | Detalle |
+|--------|---------|
+| Crea la base de datos | `allmart_db` (solo si no existe) |
+| Instala extensiones | `uuid-ossp` (UUIDs) y `pgcrypto` (cripto) |
+
+---
+
+## 2. Configurar las variables de entorno
+
+Copia `.env.example` a `.env` y completa el password de `postgres`:
+
+```bash
+cp .env.example .env
+```
+
+Edita el archivo `.env`:
+
+```dotenv
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=tu_password_de_postgres   # ← completar
+DB_NAME=allmart_db
+```
+
+> Si el usuario `postgres` no tiene contraseña configurada para conexiones TCP, establécela con:
+> ```bash
+> sudo -u postgres psql -c "ALTER ROLE postgres WITH PASSWORD 'tu_password';"
+> ```
+> Luego verifica la conexión TCP antes de arrancar el servidor:
+> ```bash
+> PGPASSWORD=tu_password psql -h localhost -U postgres -d allmart_db -c "SELECT NOW();"
+> ```
+
+---
+
+## 3. Verificar la conexión
+
+Una vez configurado el `.env`, inicia el servidor:
+
+```bash
+npm run dev
+```
+
+Si la conexión es exitosa verás en consola:
+
+```
+[DB] Conexión a PostgreSQL exitosa — servidor: 2026-02-23T...
+[Server] Escuchando en http://localhost:3001
+```
+
+Si falla, verás:
+
+```
+[DB] No se pudo conectar a PostgreSQL: <motivo del error>
+```
+
+Causas frecuentes:
+
+| Error | Solución |
+|-------|----------|
+| `password authentication failed` | Revisar `DB_PASSWORD` en `.env` |
+| `database "allmart_db" does not exist` | Ejecutar `scripts/create_db.sql` |
+| `Connection refused` | Verificar que PostgreSQL está corriendo: `pg_isready` |
+
+---
+
+## 4. Eliminar la base de datos (solo testing / reset)
+
+⚠️ **Elimina todos los datos. Solo usar en entornos de desarrollo.**
+
+```bash
+sudo -u postgres psql -f scripts/drop_db.sql
+```
+
+---
+
+## Variables de entorno de base de datos
+
+| Variable | Default | Descripción |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | Host del servidor PostgreSQL |
+| `DB_PORT` | `5432` | Puerto de PostgreSQL |
+| `DB_USER` | `postgres` | Usuario (superusuario) |
+| `DB_PASSWORD` | — | Password del usuario (requerido) |
+| `DB_NAME` | `allmart_db` | Nombre de la base de datos |
+
+---
+
+## Arquitectura del pool de conexiones
+
+```
+index.ts → connectDB()     (database.ts)  — verifica la conexión al arranque
+                └─ pool.connect()  (db.ts) — Pool singleton (max 10 conexiones)
+                      └─ env.ts            — lee las variables de entorno
+```
+
+El `pool` se importa directamente en servicios y repositorios:
+
+```ts
+import { pool } from '../config/db';
+const { rows } = await pool.query('SELECT * FROM products');
+```

--- a/backend/scripts/create_db.sql
+++ b/backend/scripts/create_db.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- Allmart — Script de creación de base de datos
+-- En Linux con peer auth ejecutar como:
+--   sudo -u postgres psql -f scripts/create_db.sql
+-- En entornos con auth TCP habilitado:
+--   PGPASSWORD=tu_password psql -h localhost -U postgres -f scripts/create_db.sql
+-- =============================================================================
+
+-- Crear la base de datos si no existe
+SELECT 'CREATE DATABASE allmart_db'
+  WHERE NOT EXISTS (
+    SELECT FROM pg_database WHERE datname = 'allmart_db'
+  )\gexec
+
+-- Conectar a la base de datos recién creada
+\connect allmart_db
+
+-- Extensiones recomendadas para un ERP escalable
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";    -- Generación de UUIDs
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";     -- Funciones criptográficas
+
+-- El superusuario postgres ya tiene todos los privilegios.
+-- No se crea un rol adicional para evitar conflictos con otros proyectos.
+
+\echo '✅  Base de datos allmart_db lista.'

--- a/backend/scripts/drop_db.sql
+++ b/backend/scripts/drop_db.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- Allmart — Script de eliminación de base de datos (SOLO testing / reset)
+-- ⚠️  PELIGRO: elimina TODOS los datos de allmart_db.
+-- En Linux con peer auth ejecutar como:
+--   sudo -u postgres psql -f scripts/drop_db.sql
+-- =============================================================================
+
+-- Cerrar conexiones activas antes de eliminar
+SELECT pg_terminate_backend(pid)
+FROM   pg_stat_activity
+WHERE  datname = 'allmart_db'
+  AND  pid <> pg_backend_pid();
+
+DROP DATABASE IF EXISTS allmart_db;
+
+\echo '🗑️   Base de datos allmart_db eliminada.'


### PR DESCRIPTION
scripts/create_db.sql — crea allmart_db (si no existe), instala extensiones uuid-ossp y pgcrypto scripts/drop_db.sql — elimina la DB (solo testing/reset) Documentación:

docs/DB_SETUP.md — guía paso a paso: crear DB, configurar .env, verificar conexión, troubleshooting, reset Configuración:

.env — DB_PASSWORD=allmart2026 (contraseña del superusuario postgres) .env.example — vars DB documentadas con nota de usar sudo -u postgres README.md — paso 3 de instalación + tabla de vars DB actualizada + referencia a docs/DB_SETUP.md