### PR TITLE
✔️ Crea la tabla categories con los campos: id, name, slug, descripti…

### DIFF
--- a/backend/migrations/002_create_categories.sql
+++ b/backend/migrations/002_create_categories.sql
@@ -1,0 +1,58 @@
+-- =============================================================================
+-- Migration: 002_create_categories
+-- Tabla de categorías de productos (cocina, baño, mate y café, etc.)
+-- Ejecutar con: npm run migrate
+-- Revertir con: npm run migrate:down (aplica sección ROLLBACK manual)
+-- =============================================================================
+
+-- ─── UP ───────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS categories (
+  id          UUID          NOT NULL DEFAULT gen_random_uuid(),
+  name        VARCHAR(150)  NOT NULL,
+  slug        VARCHAR(150)  NOT NULL,
+  description TEXT,
+  image_url   TEXT,
+  item_count  INTEGER       NOT NULL DEFAULT 0 CHECK (item_count >= 0),
+  created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT categories_pkey        PRIMARY KEY (id),
+  CONSTRAINT categories_slug_unique UNIQUE (slug)
+);
+
+-- ─── Índices ──────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_categories_slug ON categories (slug);
+
+-- ─── Trigger: actualizar updated_at automáticamente ──────────────────────────
+-- La función set_updated_at() ya fue creada en 001_create_users.sql.
+-- Se reutiliza aquí.
+DROP TRIGGER IF EXISTS trg_categories_updated_at ON categories;
+CREATE TRIGGER trg_categories_updated_at
+  BEFORE UPDATE ON categories
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ─── Trigger: recalcular item_count desde products (preparado) ────────────────
+-- Cuando se implemente la tabla products, el siguiente trigger
+-- mantendrá item_count sincronizado automáticamente.
+-- Se registra aquí como referencia para la migración de products.
+--
+-- CREATE OR REPLACE FUNCTION sync_category_item_count()
+-- RETURNS TRIGGER AS $$
+-- BEGIN
+--   UPDATE categories
+--   SET    item_count = (
+--     SELECT COUNT(*) FROM products
+--     WHERE  category_id = COALESCE(NEW.category_id, OLD.category_id)
+--       AND  status = 'active'
+--   )
+--   WHERE id = COALESCE(NEW.category_id, OLD.category_id);
+--   RETURN NEW;
+-- END;
+-- $$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- ROLLBACK (ejecutar manualmente si se necesita revertir):
+--   DROP TRIGGER IF EXISTS trg_categories_updated_at ON categories;
+--   DROP TABLE IF EXISTS categories;
+-- =============================================================================

--- a/backend/src/models/Category.ts
+++ b/backend/src/models/Category.ts
@@ -1,18 +1,28 @@
 /**
  * models/Category.ts
- * Modelo de datos para las categorías de productos.
+ * Modelo de datos alineado con la tabla PostgreSQL `categories`.
+ * Refleja exactamente los campos de migrations/002_create_categories.sql.
  */
 
+// ─── Entidad completa (espejo de la fila en BD) ───────────────────────────────
 export interface Category {
-  id: string;
-  name: string;
-  slug: string;
-  description?: string;
-  imageUrl?: string;
-  parentId?: string; // Para categorías anidadas (árbol de categorías ERP)
-  createdAt: Date;
-  updatedAt: Date;
+  id:          string;
+  name:        string;
+  slug:        string;
+  description: string | null;
+  imageUrl:    string | null;
+  itemCount:   number;
+  createdAt:   Date;
+  updatedAt:   Date;
 }
 
-export type CreateCategoryDTO = Omit<Category, 'id' | 'createdAt' | 'updatedAt'>;
-export type UpdateCategoryDTO = Partial<CreateCategoryDTO>;
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/** Datos para crear una categoría nueva (sin id ni timestamps) */
+export type CreateCategoryDTO = Omit<Category, 'id' | 'itemCount' | 'createdAt' | 'updatedAt'>;
+
+/** Actualización parcial de categoría */
+export type UpdateCategoryDTO = Partial<Omit<Category, 'id' | 'createdAt' | 'updatedAt'>>;
+
+/** Vista pública de categoría (para el frontend) */
+export type PublicCategory = Omit<Category, 'createdAt' | 'updatedAt'>;

--- a/backend/src/services/categoriesService.ts
+++ b/backend/src/services/categoriesService.ts
@@ -21,7 +21,7 @@ export async function getCategoryById(id: string): Promise<Category> {
 
 export async function createCategory(dto: CreateCategoryDTO): Promise<Category> {
   const now = new Date();
-  const category: Category = { ...dto, id: uuidv4(), createdAt: now, updatedAt: now };
+  const category: Category = { ...dto, id: uuidv4(), itemCount: 0, createdAt: now, updatedAt: now };
   store.set(category.id, category);
   return category;
 }


### PR DESCRIPTION
…on, image_url, item_count, created_at, updated_at.

✔️ El campo slug tiene restricción UNIQUE.
✔️ item_count es actualizable (por triggers o manualmente) y está preparado para ser recalculado automáticamente cuando se implemente la tabla products. ✔️ La migración es reversible: incluye instrucciones para DROP TRIGGER y DROP TABLE en la sección de rollback. ✔️ Incluye trigger para updated_at y deja preparado el trigger para item_count.