### PR TITLE
He completado la migración de ventas cerradas en 009_create_sales.sql.

### DIFF
--- a/backend/migrations/009_create_sales.sql
+++ b/backend/migrations/009_create_sales.sql
@@ -1,0 +1,52 @@
+-- =============================================================================
+-- Migration: 009_create_sales
+-- Tabla para registrar ventas cerradas (reportes y analítica).
+-- Se dispara automáticamente cuando un pedido llega al estado 'entregado'.
+-- Ejecutar con: npm run migrate
+-- Revertir con: npm run migrate:down (aplica sección ROLLBACK manual)
+-- =============================================================================
+
+-- ─── UP ───────────────────────────────────────────────────────────────────────
+
+-- ─── Tabla sales ──────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sales (
+  id          UUID           NOT NULL DEFAULT gen_random_uuid(),
+  order_id    UUID           NOT NULL,
+  total       NUMERIC(12, 2) NOT NULL CHECK (total >= 0),
+  sold_at     TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT sales_pkey         PRIMARY KEY (id),
+  CONSTRAINT sales_order_fk     FOREIGN KEY (order_id) 
+    REFERENCES orders (id) ON DELETE CASCADE,
+  CONSTRAINT sales_order_unique UNIQUE (order_id) -- Relación 1:1 definitiva
+);
+
+-- ─── Índice para reportes por fecha ──────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_sales_sold_at ON sales (sold_at);
+
+-- ─── Trigger: Registro automático de venta al entregar ───────────────────────
+CREATE OR REPLACE FUNCTION register_sale_on_delivery()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Si el estado cambia a 'entregado' y no existía ya una venta para este pedido
+  IF (NEW.status = 'entregado') AND (OLD.status IS DISTINCT FROM 'entregado') THEN
+    INSERT INTO sales (order_id, total, sold_at)
+    VALUES (NEW.id, NEW.total, NOW())
+    ON CONFLICT (order_id) DO NOTHING; -- Evita duplicados si se re-edita a entregado
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_register_sale_on_delivery ON orders;
+CREATE TRIGGER trg_register_sale_on_delivery
+  AFTER UPDATE ON orders
+  FOR EACH ROW EXECUTE FUNCTION register_sale_on_delivery();
+
+-- =============================================================================
+-- ROLLBACK (ejecutar manualmente si se necesita revertir):
+--   DROP TRIGGER IF EXISTS trg_register_sale_on_delivery ON orders;
+--   DROP FUNCTION IF EXISTS register_sale_on_delivery();
+--   DROP TABLE IF EXISTS sales;
+-- =============================================================================


### PR DESCRIPTION
Puntos clave de la implementación:
Automatización Robusta: He incluido el trigger trg_register_sale_on_delivery que detecta el cambio de estado a 'entregado' en un pedido existente e inserta automáticamente la fila en la tabla sales con el total final y la fecha de cierre. Relación 1:1: Forzada mediante la restricción UNIQUE (order_id), asegurando que cada pedido solo genere una venta en los reportes, incluso si se mueve de estado varias veces. Índice para Analítica: He añadido un índice en sold_at para optimizar consultas de reportes por rangos de fecha (ej: Ventas Mensuales o Diarias). Consistencia: Utilización de ON CONFLICT (order_id) DO NOTHING para evitar errores si un pedido se marca como entregado, luego se cambia y se vuelve a marcar como entregado.

- [x] Crear migración 009_create_sales.sql- [x] Relación 1:1 con orders via UNIQUE y CASCADE- [x] Trigger automático para registrar venta al pasar a 'entregado'- [x] Índice en sold_at para reportes rápidos- [x] Sección ROLLBACK