### PR TITLE
Resumen de los cambios realizados:

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -11,13 +11,6 @@ export const env = {
   JWT_SECRET: process.env.JWT_SECRET || 'allmart_super_secret',
   NODE_ENV: process.env.NODE_ENV || 'development',
 
-  // Admin credentials (in-memory, migrate to DB when available)
-  ADMIN_USER: process.env.ADMIN_USER || 'admin',
-  ADMIN_HASH: process.env.ADMIN_HASH || '$2b$10$zLj./2iqsqnoBqxpT92mVOwUtayNkYy6tL8in443IuB82L905yOau',
-
-  EDITOR_USER: process.env.EDITOR_USER || 'editor',
-  EDITOR_HASH: process.env.EDITOR_HASH || '$2b$10$mt.YMa6mFiMmnnxRettsAO/brFQfx1rJQBWFN.HePpYNYtoj7ZRhu',
-
   // ─── PostgreSQL ───────────────────────────────────────────────────────────
   DB_HOST:     process.env.DB_HOST     || 'localhost',
   DB_PORT:     parseInt(process.env.DB_PORT || '5432', 10),

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,25 +1,13 @@
 /**
  * services/authService.ts
  * Lógica de negocio para autenticación de administradores.
- * Actualmente usa usuarios en memoria; migrar a BD cuando esté disponible.
+ * Valida credenciales contra la tabla users de la base de datos.
  */
 
-import { env } from '../config/env';
+import { pool } from '../config/db';
 import { comparePassword } from '../utils/bcrypt';
 import { signToken } from '../utils/jwt';
 import { UserRole } from '../types';
-
-interface InMemoryUser {
-  user: string;
-  hash: string;
-  role: UserRole;
-}
-
-// En memoria hasta integrar BD
-const USERS: InMemoryUser[] = [
-  { user: env.ADMIN_USER,  hash: env.ADMIN_HASH,  role: UserRole.ADMIN  },
-  { user: env.EDITOR_USER, hash: env.EDITOR_HASH, role: UserRole.EDITOR },
-];
 
 export interface LoginResult {
   token: string;
@@ -27,12 +15,28 @@ export interface LoginResult {
 }
 
 export async function login(username: string, password: string): Promise<LoginResult> {
-  const found = USERS.find(u => u.user === username);
-  if (!found) throw Object.assign(new Error('Usuario inválido'), { statusCode: 401 });
+  // Solo admin y editor tienen acceso al panel de administración
+  const { rows } = await pool.query<{ id: string; email: string; password_hash: string; role: UserRole }>(
+    `SELECT id, email, password_hash, role
+     FROM users
+     WHERE email = $1
+       AND role IN ('admin', 'editor')
+       AND is_active = TRUE
+     LIMIT 1`,
+    [username]
+  );
 
-  const valid = await comparePassword(password, found.hash);
-  if (!valid) throw Object.assign(new Error('Contraseña incorrecta'), { statusCode: 401 });
+  if (rows.length === 0) {
+    throw Object.assign(new Error('Credenciales inválidas'), { statusCode: 401 });
+  }
 
-  const token = signToken({ user: found.user, role: found.role });
-  return { token, role: found.role };
+  const user = rows[0];
+
+  const valid = await comparePassword(password, user.password_hash);
+  if (!valid) {
+    throw Object.assign(new Error('Credenciales inválidas'), { statusCode: 401 });
+  }
+
+  const token = signToken({ userId: user.id, user: user.email, role: user.role });
+  return { token, role: user.role };
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -8,6 +8,7 @@ export * from './enums';
 
 // ─── Payload JWT ──────────────────────────────────────────────────────────────
 export interface JwtPayload {
+  userId: string;
   user: string;
   role: string;
   iat?: number;


### PR DESCRIPTION
authService.ts — Migración completa de in-memory a DB:

Consulta users filtrando por email, role IN ('admin', 'editor') y is_active = TRUE. Usa bcrypt.compare para verificar la contraseña contra password_hash. Firma el JWT con { userId, user, role } y expiración de 2h (default de signToken). Mensaje de error genérico 'Credenciales inválidas' para ambos casos (usuario no encontrado / contraseña incorrecta) — buena práctica de seguridad. index.ts — JwtPayload actualizado con userId: string.

env.ts — Eliminadas las variables huérfanas ADMIN_USER, ADMIN_HASH, EDITOR_USER, EDITOR_HASH.

El controlador y el middleware existentes no requirieron cambios; ya estaban correctamente desacoplad