### PR TITLE
 he solucionado el problema de concurrencia en los workflows que usan…

### DIFF
--- a/.github/workflows/actualizar_puntajes_semanal.yml
+++ b/.github/workflows/actualizar_puntajes_semanal.yml
@@ -1,4 +1,9 @@
+
 name: Actualización automática de puntajes
+
+concurrency:
+  group: actualizacion-puntajes-semanal-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   schedule:

--- a/.github/workflows/puntajes_gestion.yml
+++ b/.github/workflows/puntajes_gestion.yml
@@ -1,4 +1,9 @@
+
 name: Registrar puntajes de gestión
+
+concurrency:
+  group: gestion-puntaje-auto-${{ github.ref }}
+  cancel-in-progress: true
 
 # Captura todas las actividades de gestión que merecen puntaje
 on:


### PR DESCRIPTION
… peter-evans/create-pull-request@v6. Ahora, solo se ejecutará una instancia a la vez por rama objetivo, evitando el error de push concurrente.