### PR TITLE
He actualizado el archivo ci-cd.yml para que el proceso de despliegue…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,8 @@
 #   - VPS_DB_NAME             Nombre de la base de datos en producción
 #   - VPS_JWT_SECRET          JWT secret para producción (mínimo 64 chars)
 #   - VPS_CORS_ORIGIN         URL del frontend en el VPS (ej: http://IP:8082)
+#   - VPS_SEED_ADMIN_PASSWORD Contraseña inicial para el usuario admin@admin.com
+#   - VPS_SEED_EDITOR_PASSWORD Contraseña inicial para el usuario editor@admin.com
 #   - GITGUARDIAN_API_KEY     API key de GitGuardian para escaneo de secretos
 # =============================================================================
 
@@ -173,12 +175,14 @@ jobs:
             DB_USER=${{ secrets.VPS_DB_USER }}
             DB_PASSWORD=${{ secrets.VPS_DB_PASSWORD }}
             DB_NAME=${{ secrets.VPS_DB_NAME }}
-            DB_PORT_HOST=5433
+            DB_PORT_HOST=5434
             NODE_ENV=production
             BACKEND_PORT=3002
             FRONTEND_PORT=8082
             JWT_SECRET=${{ secrets.VPS_JWT_SECRET }}
             CORS_ORIGIN=${{ secrets.VPS_CORS_ORIGIN }}
+            SEED_ADMIN_PASSWORD=${{ secrets.VPS_SEED_ADMIN_PASSWORD }}
+            SEED_EDITOR_PASSWORD=${{ secrets.VPS_SEED_EDITOR_PASSWORD }}
             DATABASE_URL=postgresql://${{ secrets.VPS_DB_USER }}:${{ secrets.VPS_DB_PASSWORD }}@db:5432/${{ secrets.VPS_DB_NAME }}?schema=public
             EOF
 


### PR DESCRIPTION
… sea robusto y use los nuevos parámetros. Aquí tienes el resumen de los cambios:

Cambio de puerto: Se actualizó el puerto de la base de datos de 5433 a 5434 en el script de generación del .env para evitar el conflicto de "port already allocated" en el VPS. Soporte para Seed: Se añadieron las variables SEED_ADMIN_PASSWORD y SEED_EDITOR_PASSWORD al archivo .env de producción. Estas variables ahora se leen desde los secrets de GitHub: ${{ secrets.VPS_SEED_ADMIN_PASSWORD }}
${{ secrets.VPS_SEED_EDITOR_PASSWORD }}
Documentación del Workflow: He añadido los nuevos secrets requeridos a la cabecera del archivo de workflow para facilitar futuras configuraciones.