### PR TITLE
ambios realizados

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,8 +132,6 @@ jobs:
           tags: |
             ${{ env.FRONTEND_IMAGE }}:latest
             ${{ env.FRONTEND_IMAGE }}:${{ steps.meta.outputs.image_tag }}
-          build-args: |
-            VITE_API_URL=http://${{ env.VPS_HOST }}:3002
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/frontend/src/pages/AdminLogin/AdminLogin.tsx
+++ b/frontend/src/pages/AdminLogin/AdminLogin.tsx
@@ -17,8 +17,7 @@ export function AdminLogin() {
     setError('');
     setLoading(true);
     try {
-      const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
-      const res = await fetch(`${apiUrl}/api/admin/auth/login`, {
+      const res = await fetch('/api/admin/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ user, password }),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
AdminLogin.tsx: Cambié el fetch de URL absoluta (http://localhost:3001/api/...) a URL relativa (/api/admin/auth/login). Nginx ya hace el proxy internamente.

vite.config.ts: Agregué proxy para desarrollo local. Sin esto, las URLs relativas fallarían en npm run dev.

ci-cd.yml: Eliminé el build-args: VITE_API_URL=http://IP:3002 del build de la imagen del frontend. Ya no es necesario porque nginx maneja el proxy.

.env: Eliminé VITE_API_URL que ya no se usa.