### PR TITLE
fix: corregir error TS en authService, seed actualiza password en ups…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -195,11 +195,23 @@ jobs:
             update_env "CORS_ORIGIN" "${{ secrets.VPS_CORS_ORIGIN }}"
             
             # Solo actualizar seed passwords si el secret NO está vacío en GitHub
-            if [ -n "${{ secrets.VPS_SEED_ADMIN_PASSWORD }}" ]; then
-              update_env "SEED_ADMIN_PASSWORD" "${{ secrets.VPS_SEED_ADMIN_PASSWORD }}"
+            SEED_ADMIN="${{ secrets.VPS_SEED_ADMIN_PASSWORD }}"
+            SEED_EDITOR="${{ secrets.VPS_SEED_EDITOR_PASSWORD }}"
+            if [ -n "$SEED_ADMIN" ]; then
+              update_env "SEED_ADMIN_PASSWORD" "$SEED_ADMIN"
             fi
-            if [ -n "${{ secrets.VPS_SEED_EDITOR_PASSWORD }}" ]; then
-              update_env "SEED_EDITOR_PASSWORD" "${{ secrets.VPS_SEED_EDITOR_PASSWORD }}"
+            if [ -n "$SEED_EDITOR" ]; then
+              update_env "SEED_EDITOR_PASSWORD" "$SEED_EDITOR"
+            fi
+
+            # Garantizar que SEED passwords existan en .env (fallback si secrets están vacíos)
+            if ! grep -q "^SEED_ADMIN_PASSWORD=." .env; then
+              echo "WARN: SEED_ADMIN_PASSWORD vacío. Configurando valor por defecto."
+              update_env "SEED_ADMIN_PASSWORD" "Admin2026!"
+            fi
+            if ! grep -q "^SEED_EDITOR_PASSWORD=." .env; then
+              echo "WARN: SEED_EDITOR_PASSWORD vacío. Configurando valor por defecto."
+              update_env "SEED_EDITOR_PASSWORD" "Editor2026!"
             fi
 
             # Construir DATABASE_URL dinámicamente si falta

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -34,10 +34,13 @@ async function seed() {
     const hashedAdmin = await bcrypt.hash(adminPassword, 10);
     const hashedEditor = await bcrypt.hash(editorPassword, 10);
 
-    // ADMIN
+    // ADMIN — update: siempre sincroniza el hash con la variable de entorno
     await prisma.user.upsert({
       where: { email: 'admin@admin.com' },
-      update: {},
+      update: {
+        passwordHash: hashedAdmin,
+        isActive: true,
+      },
       create: {
         firstName: 'Admin',
         lastName: 'Principal',
@@ -48,10 +51,13 @@ async function seed() {
       },
     });
 
-    // EDITOR
+    // EDITOR — update: siempre sincroniza el hash con la variable de entorno
     await prisma.user.upsert({
       where: { email: 'editor@admin.com' },
-      update: {},
+      update: {
+        passwordHash: hashedEditor,
+        isActive: true,
+      },
       create: {
         firstName: 'Editor',
         lastName: 'Principal',

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -26,10 +26,10 @@ export interface LoginResult {
  * Valida credenciales contra la tabla users usando Prisma.
  * Solo para roles admin y editor.
  */
-export async function login(email: string, password: string): Promise<LoginResult> {
+export async function login(username: string, password: string): Promise<LoginResult> {
   const user = await prisma.user.findFirst({
     where: {
-      email: email,
+      email: username,
       role: { in: ['admin', 'editor'] },
       isActive: true,
     },
@@ -46,7 +46,7 @@ export async function login(email: string, password: string): Promise<LoginResul
   }
 
   const role = user.role as unknown as UserRole;
-  const token = signToken({ userId: user.id, email: user.email, role });
+  const token = signToken({ userId: user.id, user: user.email, role });
   return { token, role, userId: user.id };
 }
 


### PR DESCRIPTION
…ert, fallback para seed passwords en CI/CD

- Revertir cambio de 'user' a 'email' en JWT payload (tipo JwtPayload usa 'user')
- Seed ahora actualiza passwordHash en upsert (antes update: {} no cambiaba nada)
- CI/CD tiene fallback para SEED passwords si los GitHub Secrets están vacíos