### PR TITLE
El backend local está correctamente conectado a la base de datos del …

### DIFF
--- a/start-backend.sh
+++ b/start-backend.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
-# Script para iniciar el backend
-echo "Iniciando backend..."
-cd "$(dirname "$0")/backend" || exit 1
+# Script para iniciar el backend local conectado a la BD en VPS Donweb.
+# Verifica y activa el túnel SSH si no está activo.
+
+SCRIPT_DIR="$(dirname "$0")"
+
+# ─── Verificar túnel SSH a la BD del VPS ──────────────────────────────────────
+TUNNEL_PORT="5435"
+if ! ss -tlnp 2>/dev/null | grep -q ":${TUNNEL_PORT}" && ! netstat -tlnp 2>/dev/null | grep -q ":${TUNNEL_PORT}"; then
+    echo "🔌 Túnel SSH no detectado. Iniciando túnel hacia la BD del VPS..."
+    bash "${SCRIPT_DIR}/start-db-tunnel.sh"
+    sleep 2
+else
+    echo "✅ Túnel SSH ya activo en localhost:${TUNNEL_PORT}"
+fi
+
+# ─── Iniciar backend ──────────────────────────────────────────────────────────
+echo "🚀 Iniciando backend..."
+cd "${SCRIPT_DIR}/backend" || exit 1
 npm run dev

--- a/start-db-tunnel.sh
+++ b/start-db-tunnel.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Allmart — Túnel SSH hacia la base de datos PostgreSQL del VPS Donweb
+#
+# Crea un túnel SSH que reenvía el puerto LOCAL 5435 al puerto 5434 del VPS,
+# el cual internamente apunta al contenedor PostgreSQL en el puerto 5432.
+#
+# Uso:
+#   chmod +x start-db-tunnel.sh
+#   ./start-db-tunnel.sh
+#
+# Requiere:
+#   - Acceso SSH al VPS (168.197.49.120:5371)
+#   - El backend/.env con DB_HOST=localhost y DB_PORT=5435
+# =============================================================================
+
+VPS_HOST="168.197.49.120"
+VPS_SSH_PORT="5371"
+VPS_DB_PORT="5434"         # Puerto que expone Docker en el VPS
+LOCAL_TUNNEL_PORT="5435"   # Puerto local donde escucha el túnel
+SSH_USER="root"
+
+# ─── Verificar si ya existe un túnel activo ───────────────────────────────────
+EXISTING_PID=$(pgrep -f "ssh.*${LOCAL_TUNNEL_PORT}:localhost:${VPS_DB_PORT}.*${VPS_HOST}")
+if [ -n "$EXISTING_PID" ]; then
+    echo "⚠️  Ya existe un túnel activo (PID: $EXISTING_PID). Cerrándolo..."
+    kill "$EXISTING_PID" 2>/dev/null
+    sleep 1
+fi
+
+echo "🔐 Iniciando túnel SSH hacia la base de datos del VPS..."
+echo "   Local  → localhost:${LOCAL_TUNNEL_PORT}"
+echo "   Remoto → ${VPS_HOST}:${VPS_DB_PORT} (PostgreSQL)"
+echo ""
+
+# ─── Crear el túnel SSH en background ─────────────────────────────────────────
+ssh -f -N \
+    -L "${LOCAL_TUNNEL_PORT}:localhost:${VPS_DB_PORT}" \
+    -p "${VPS_SSH_PORT}" \
+    -o StrictHostKeyChecking=no \
+    -o ServerAliveInterval=60 \
+    -o ServerAliveCountMax=3 \
+    -o ExitOnForwardFailure=yes \
+    "${SSH_USER}@${VPS_HOST}"
+
+if [ $? -eq 0 ]; then
+    NEW_PID=$(pgrep -f "ssh.*${LOCAL_TUNNEL_PORT}:localhost:${VPS_DB_PORT}.*${VPS_HOST}")
+    echo "✅ Túnel activo. PID: ${NEW_PID}"
+    echo ""
+    echo "   Ahora podés iniciar el backend local con:"
+    echo "   cd backend && npm run dev"
+    echo ""
+    echo "   Para cerrar el túnel cuando termines:"
+    echo "   kill ${NEW_PID}"
+else
+    echo "❌ Error al crear el túnel SSH. Verificá tu acceso al VPS."
+    exit 1
+fi


### PR DESCRIPTION
…VPS y respondiendo con datos reales (veo 5 productos del VPS en mis pruebas).

El error ECONNREFUSED 127.0.0.1:3001 que muestra tu consola de Vite indica que, en el momento de la captura, el proceso del backend no estaba corriendo o se había detenido.