### PR TITLE
Resultado

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,21 +173,28 @@ jobs:
           username: ${{ env.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
-            set -e
+            set -Eeuo pipefail
             cd ${{ env.DEPLOY_DIR }}
+
+            on_error() {
+              echo "ERROR: el despliegue falló. Estado y logs de diagnóstico:"
+              docker compose -f docker-compose.prod.yml ps || true
+              docker compose -f docker-compose.prod.yml logs --tail=200 db backend frontend || true
+            }
+            trap on_error ERR
 
             echo "Sincronizando .env de produccion..."
             
             # 1. Asegurar que .env exista
             touch .env
 
-            # 2. Función robusa para actualizar .env sin problemas de caracteres especiales
+            # 2. Función robusta para actualizar .env sin romper valores con saltos de línea
             update_env() {
               key=$1
-              value=$2
+              value=$(printf '%s' "$2" | tr -d '\r' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
               # Eliminar la línea si ya existe y añadirla limpia
               grep -v "^${key}=" .env > .env.tmp || true
-              echo "${key}=${value}" >> .env.tmp
+              printf '%s\n' "${key}=${value}" >> .env.tmp
               mv .env.tmp .env
             }
 
@@ -223,11 +230,15 @@ jobs:
               update_env "SEED_EDITOR_PASSWORD" "Editor2026!"
             fi
 
-            # Construir DATABASE_URL dinámicamente si falta
+            # Construir DATABASE_URL dinámicamente (codificando credenciales para caracteres especiales)
             DB_USER_VAL=$(grep "^DB_USER=" .env | cut -d'=' -f2-)
             DB_PASS_VAL=$(grep "^DB_PASSWORD=" .env | cut -d'=' -f2-)
             DB_NAME_VAL=$(grep "^DB_NAME=" .env | cut -d'=' -f2-)
-            update_env "DATABASE_URL" "postgresql://${DB_USER_VAL}:${DB_PASS_VAL}@db:5432/${DB_NAME_VAL}?schema=public"
+
+            DB_USER_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_USER_VAL")
+            DB_PASS_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_PASS_VAL")
+            DB_NAME_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_NAME_VAL")
+            update_env "DATABASE_URL" "postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@db:5432/${DB_NAME_ENC}?schema=public"
 
             echo "Descargando imagenes actualizadas..."
             docker pull ${{ env.BACKEND_IMAGE }}:${{ needs.docker-build-push.outputs.image_tag }}
@@ -235,7 +246,7 @@ jobs:
 
             echo "Reiniciando contenedores..."
             docker compose -f docker-compose.prod.yml down --remove-orphans || true
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml up -d --wait --wait-timeout 240
 
             echo "Estado final:"
             docker compose -f docker-compose.prod.yml ps

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,10 +63,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/"]
-      interval: 30s
+      interval: 20s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 8
+      start_period: 120s
     networks:
       - allmart-prod-network
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+on_error() {
+  warn "El despliegue falló. Estado y logs de diagnóstico:"
+  docker compose -f "$COMPOSE_FILE" ps || true
+  docker compose -f "$COMPOSE_FILE" logs --tail=200 db backend frontend || true
+}
+trap on_error ERR
+
 # ─── Configuración ────────────────────────────────────────────────────────────
 DEPLOY_DIR="/opt/allmart"
 COMPOSE_FILE="docker-compose.prod.yml"
@@ -53,9 +60,28 @@ if docker network ls --format '{{.Name}}' | grep -q '^allmart_allmart-prod-netwo
   docker network rm allmart_allmart-prod-network || warn "No se pudo eliminar la red allmart_allmart-prod-network"
 fi
 
+update_env() {
+  key=$1
+  value=$(printf '%s' "$2" | tr -d '\r' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+  grep -v "^${key}=" .env > .env.tmp || true
+  printf '%s\n' "${key}=${value}" >> .env.tmp
+  mv .env.tmp .env
+}
+
 # ─── Verificar que existe el .env ─────────────────────────────────────────────
 if [ ! -f ".env" ]; then
   error "No se encontró .env en $DEPLOY_DIR. Crea uno a partir de .env.vps.example"
+fi
+
+if grep -q '^DB_USER=' .env && grep -q '^DB_PASSWORD=' .env && grep -q '^DB_NAME=' .env; then
+  DB_USER_VAL=$(grep '^DB_USER=' .env | cut -d'=' -f2-)
+  DB_PASS_VAL=$(grep '^DB_PASSWORD=' .env | cut -d'=' -f2-)
+  DB_NAME_VAL=$(grep '^DB_NAME=' .env | cut -d'=' -f2-)
+
+  DB_USER_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_USER_VAL")
+  DB_PASS_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_PASS_VAL")
+  DB_NAME_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_NAME_VAL")
+  update_env "DATABASE_URL" "postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@db:5432/${DB_NAME_ENC}?schema=public"
 fi
 
 # ─── Verificar que existe docker-compose.prod.yml ─────────────────────────────
@@ -75,7 +101,7 @@ docker compose -f "$COMPOSE_FILE" down --remove-orphans || warn "No había conte
 
 # ─── Levantar los nuevos contenedores ─────────────────────────────────────────
 log "Levantando contenedores de producción..."
-docker compose -f "$COMPOSE_FILE" up -d
+docker compose -f "$COMPOSE_FILE" up -d --wait --wait-timeout 240
 
 # ─── Verificar que los contenedores están corriendo ───────────────────────────
 log "Esperando que los servicios estén listos (30s)..."


### PR DESCRIPTION
No te puedo prometer “siempre” en sentido absoluto (si la app o la DB realmente fallan, debe fallar), pero ahora: El deploy es resistente a los fallos más comunes de .env y DATABASE_URL. Espera correctamente la salud de servicios.
Si falla, deja diagnóstico completo en el job para resolver rápido. Siguiente paso natural:

Haz commit/push de estos cambios y re-ejecuta el workflow de main. Si vuelve a caer, ahora el job ya mostrará logs de db/backend/frontend y te doy fix exacto en una pasada