### PR TITLE
Cambié backend a CommonJS para que coincida con lo que genera tsc:

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -230,15 +230,7 @@ jobs:
               update_env "SEED_EDITOR_PASSWORD" "Editor2026!"
             fi
 
-            # Construir DATABASE_URL dinámicamente (codificando credenciales para caracteres especiales)
-            DB_USER_VAL=$(grep "^DB_USER=" .env | cut -d'=' -f2-)
-            DB_PASS_VAL=$(grep "^DB_PASSWORD=" .env | cut -d'=' -f2-)
-            DB_NAME_VAL=$(grep "^DB_NAME=" .env | cut -d'=' -f2-)
-
-            DB_USER_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_USER_VAL")
-            DB_PASS_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_PASS_VAL")
-            DB_NAME_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_NAME_VAL")
-            update_env "DATABASE_URL" "postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@db:5432/${DB_NAME_ENC}?schema=public"
+            # No construir DATABASE_URL en host VPS: backend usa DB_* directamente via Prisma adapter
 
             echo "Descargando imagenes actualizadas..."
             docker pull ${{ env.BACKEND_IMAGE }}:${{ needs.docker-build-push.outputs.image_tag }}

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,10 +1,10 @@
-import { defineConfig } from "eslint/config";
-import js from "@eslint/js";
-import globals from "globals";
-import tseslint from "@typescript-eslint/eslint-plugin";
-import tsParser from "@typescript-eslint/parser";
+const { defineConfig } = require("eslint/config");
+const js = require("@eslint/js");
+const globals = require("globals");
+const tseslint = require("@typescript-eslint/eslint-plugin");
+const tsParser = require("@typescript-eslint/parser");
 
-export default defineConfig([
+module.exports = defineConfig([
   js.configs.recommended,
   {
     files: ["**/*.ts", "**/*.tsx"],

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "allmart-backend",
   "version": "1.0.0",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,7 +51,6 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}?schema=public
       JWT_SECRET: ${JWT_SECRET}
       CORS_ORIGIN: ${CORS_ORIGIN}
       SEED_ADMIN_PASSWORD: ${SEED_ADMIN_PASSWORD}

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -73,16 +73,7 @@ if [ ! -f ".env" ]; then
   error "No se encontró .env en $DEPLOY_DIR. Crea uno a partir de .env.vps.example"
 fi
 
-if grep -q '^DB_USER=' .env && grep -q '^DB_PASSWORD=' .env && grep -q '^DB_NAME=' .env; then
-  DB_USER_VAL=$(grep '^DB_USER=' .env | cut -d'=' -f2-)
-  DB_PASS_VAL=$(grep '^DB_PASSWORD=' .env | cut -d'=' -f2-)
-  DB_NAME_VAL=$(grep '^DB_NAME=' .env | cut -d'=' -f2-)
-
-  DB_USER_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_USER_VAL")
-  DB_PASS_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_PASS_VAL")
-  DB_NAME_ENC=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$DB_NAME_VAL")
-  update_env "DATABASE_URL" "postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@db:5432/${DB_NAME_ENC}?schema=public"
-fi
+# No construir DATABASE_URL en host VPS: backend usa DB_* directamente via Prisma adapter
 
 # ─── Verificar que existe docker-compose.prod.yml ─────────────────────────────
 if [ ! -f "$COMPOSE_FILE" ]; then


### PR DESCRIPTION
package.json

Convertí la config de ESLint del backend a CommonJS para que siga funcionando:

eslint.config.js

Eliminé del CI la construcción de DATABASE_URL en el host VPS (ya no usa node -e):

ci-cd.yml:233

Eliminé lo mismo en el script manual de despliegue:

deploy-vps.sh:76

Quité DATABASE_URL del compose de producción para evitar interpolaciones frágiles; backend usa DB_* directo en Prisma adapter: