### PR TITLE
Cambios:

### DIFF
--- a/frontend/src/pages/Admin/AdminLayout.tsx
+++ b/frontend/src/pages/Admin/AdminLayout.tsx
@@ -2,7 +2,7 @@
 import { useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect, useRef } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { NavLink, Outlet } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 import { useAdminAuth } from "../../context/AdminAuthContext";
 import { useAdminOrders } from "../../context/AdminOrdersContext";
@@ -74,7 +74,6 @@ export function AdminLayout() {
   const { user, role, logout, can } = useAdminAuth();
   const { getPendingOrdersCount } = useAdminOrders();
   const { getLowStockCount } = useAdminProducts();
-  const navigate = useNavigate();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
@@ -122,7 +121,7 @@ export function AdminLayout() {
 
   const handleLogout = () => {
     logout();
-    navigate("/admin/login");
+    window.location.replace('/');
   };
 
   return (


### PR DESCRIPTION
En AdminLayout.tsx:123, el logout ahora hace:
limpiar sesión
redirección forzada del navegador al home del ecommerce con window.location.replace("/") En AdminRoute.tsx:12, dejé la lógica estándar:
si no hay sesión en rutas admin, redirige a /admin/login Por qué esto sí lo corrige:

La redirección forzada del navegador sale inmediatamente del árbol de rutas admin, así que el guard ya no “gana” la carrera hacia /admin/login durante el cierre desde el sidebar. Validación:

Sin errores en ambos archivos modificados.