### PR TITLE
453 mejorar visualización de gráficos comparativos y tendencias

### DIFF
--- a/frontend/src/features/admin/reports/AdminReports.module.css
+++ b/frontend/src/features/admin/reports/AdminReports.module.css
@@ -133,6 +133,77 @@
     color: #1a1a1a;
   }
 
+  /* === Sales Cards (mobile) === */
+  .salesCardsWrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+    max-height: 500px;
+    overflow-y: scroll;
+  }
+
+  .salesCard {
+    background: #fff;
+    border: 1px solid #e5e2dd;
+    border-radius: 12px;
+    padding: 0.9rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    box-shadow: 0 1px 4px #0001;
+  }
+
+  .salesCardHeader {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    gap: 0.5rem;
+  }
+
+  .salesCardDate {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #444;
+  }
+
+  .salesCardTotal {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #2e7d32;
+    white-space: nowrap;
+  }
+
+  .salesCardProducts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .salesCardProduct {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    color: #555;
+    padding: 2px 0;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  .salesCardProduct:last-of-type {
+    border-bottom: none;
+  }
+
+  .salesCardQty {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #888;
+    background: #f5f5f5;
+    border-radius: 999px;
+    padding: 1px 8px;
+    white-space: nowrap;
+  }
 
 
   /* === Advanced Filters === */
@@ -1526,6 +1597,14 @@ ALLMART — ADMIN REPORTS
   color: var(--color-text-tertiary);
 }
 
+.viewToggleGroup {
+  margin-bottom: 1rem;
+}
+
+.viewToggle {
+  margin-bottom: 1rem;
+}
+
 .viewToggleLabel {
   padding-left: 5px;
   display: block;
@@ -1550,6 +1629,13 @@ ALLMART — ADMIN REPORTS
 .toggleBtn:hover {
   background: color-mix(in srgb, var(--color-primary) 10%, transparent);
   color: var(--color-primary-dark);
+}
+
+@media (max-width: 600px) {
+  .toggleBtn {
+    font-size: var(--text-sm);
+    padding: var(--space-2) var(--space-4);
+  }
 }
 
 .noData {

--- a/frontend/src/features/admin/reports/AdminReports.tsx
+++ b/frontend/src/features/admin/reports/AdminReports.tsx
@@ -1,6 +1,6 @@
 
 import React, { useMemo, useState, useEffect, useRef } from 'react';
-//import { useAdminOrders } from '../../../context/AdminOrdersContext';
+import { useAdminOrders } from '../../../context/AdminOrdersContext';
 import type { Order } from '../../../context/AdminOrdersContext';
 import sectionStyles from '../shared/AdminSection.module.css';
 import styles from './AdminReports.module.css';
@@ -16,7 +16,7 @@ import { Suspense } from 'react';
 import { Notification } from '../../../components/ui/Notification';
 import { ConfirmModal } from '../../../components/ui/ConfirmModal';
 import { exportOrdersCSV, exportOrdersXLSX, exportOrdersPDF, getExportFileName } from '../../../utils/exportHelpers';
-import { generateMockOrders } from './components/DatosMockeados';
+//import { generateMockOrders } from './components/DatosMockeados';
 import { ProductRanking } from './components/ReportsProductRanking';
 import { OrdersFilters } from './components/OrdersFilters';
 import { SalesTableView } from './components/SalesTableView';
@@ -96,8 +96,8 @@ export interface OrdersTableProps {
  */
 export function AdminReports() {
 
-  //const { orders } = useAdminOrders();
-  const orders = useMemo(() => generateMockOrders(50), []);
+  const { orders } = useAdminOrders();
+  //const orders = useMemo(() => generateMockOrders(50), []);
   const [isLoading] = useState(false);
   const [filters, setFilters] = useState<ReportsFiltersValue>({ type: 'predefined', period: '30d' });
   // Unsaved changes detection

--- a/frontend/src/features/admin/reports/AdminReports.tsx
+++ b/frontend/src/features/admin/reports/AdminReports.tsx
@@ -608,7 +608,7 @@ export function AdminReports() {
                 {' · '}ingresos de pedidos activos
               </span>
             </div>
-            <div className={styles.viewToggle}>
+            <div className={styles.viewToggleGroup + ' fadeInFast'}>
               <span className={styles.viewToggleLabel}>Vista:</span>
 
               <button

--- a/frontend/src/features/admin/reports/components/BarChart.tsx
+++ b/frontend/src/features/admin/reports/components/BarChart.tsx
@@ -96,7 +96,7 @@ const BarChart = ({ data, formatValue }: Props) => {
     const step = (dynamicW - padLeft - padRight) / data.length;
 
     const barW = Math.max(10, step - gap);
-    const showAllLabels = data.length <= 30;
+    const showAllLabels = data.length <= 90;
 
     const hoveredItem =
         hoveredIdx !== null ? data[hoveredIdx] : null;

--- a/frontend/src/features/admin/reports/components/SalesTableView.tsx
+++ b/frontend/src/features/admin/reports/components/SalesTableView.tsx
@@ -20,9 +20,21 @@ type DayData = {
     products: Product[];
 };
 
+function useIsMobile() {
+    const [isMobile, setIsMobile] = useState(() =>
+        typeof window !== 'undefined' ? window.innerWidth <= 600 : false
+    );
+    useEffect(() => {
+        const handler = () => setIsMobile(window.innerWidth <= 600);
+        window.addEventListener('resize', handler);
+        return () => window.removeEventListener('resize', handler);
+    }, []);
+    return isMobile;
+}
 
 export function SalesTableView({ orders, formatPrice, dayKeys }: Props) {
     const [selectedDay, setSelectedDay] = useState<DayData | null>(null);
+    const isMobile = useIsMobile();
 
     const data = useMemo(() => {
         const map = new Map<string, DayData>();
@@ -105,6 +117,85 @@ export function SalesTableView({ orders, formatPrice, dayKeys }: Props) {
     }, []);
 
 
+    // Vista mobile: cards
+    if (isMobile) {
+        return (
+            <>
+                <div className={styles.salesCardsWrap}>
+                    {data.map(day => {
+                        const hasMore = day.products.length > 3;
+                        const visibleProducts = day.products.slice(0, 3);
+
+                        return (
+                            <div key={day.dateKey} className={styles.salesCard}>
+                                <div className={styles.salesCardHeader}>
+                                    <span className={styles.salesCardDate}>
+                                        📅 {formatDate(day.dateKey)}
+                                    </span>
+                                    <span className={styles.salesCardTotal}>
+                                        {formatPrice(day.total)}
+                                    </span>
+                                </div>
+                                <div className={styles.salesCardProducts}>
+                                    {day.products.length === 0 ? (
+                                        <span className={styles.noDataProducts}>Sin ventas</span>
+                                    ) : (
+                                        visibleProducts.map((p, i) => (
+                                            <span key={i} className={styles.salesCardProduct}>
+                                                {p.name}
+                                                <span className={styles.salesCardQty}>x{p.qty}</span>
+                                            </span>
+                                        ))
+                                    )}
+                                    {hasMore && (
+                                        <button
+                                            className={styles.viewMoreBtn}
+                                            onClick={() => setSelectedDay(day)}
+                                        >
+                                            Ver más ({day.products.length})
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {/* Modal igual que antes */}
+                {selectedDay && (
+                    <div className={styles.modalOverlay}>
+                        <div
+                            className={styles.modalContent}
+                            role="dialog"
+                            aria-modal="true"
+                        >
+                            <div className={styles.modalHeader}>
+                                <h3>
+                                    📅 {formatDate(selectedDay.dateKey)} — {formatPrice(selectedDay.total)}
+                                </h3>
+
+                                <button
+                                    className={styles.modalClose}
+                                    onClick={() => setSelectedDay(null)}
+                                >
+                                    ✕
+                                </button>
+                            </div>
+
+                            <div className={styles.modalBody}>
+                                {selectedDay.products.map((p, i) => (
+                                    <div key={i} className={styles.modalRow}>
+                                        <span>{p.name}</span>
+                                        <strong>x{p.qty}</strong>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </>
+        );
+    }
 
     return (
         <>


### PR DESCRIPTION
Corregí un error de visualización en el grafico de barra que si filtraba por ultimos 90 días solo se veian las barras y no aparecía el label debajo de cada una de estas indicando el día, además hice un ajuste pequeño en el layout mobile en el modo de visualización tabla haciendo que se visualicen como cards en ves de una tabla con scrolls