### PR TITLE
Cambios aplicados en un solo edit:

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -78,9 +78,6 @@ e2e/
 # Misc
 .prettierrc
 .eslintrc*
-tsconfig*.json
 vitest.config.ts
 jest.config.js
-vite.config.ts
 .npmrc
-nginx.conf


### PR DESCRIPTION
Fichero eliminado del .dockerignore	Por qué se necesita nginx.conf	Stage 3 (COPY nginx.conf ...) lo requiere para configurar nginx vite.config.ts	Stage de build (npm run build) usa Vite y necesita su config tsconfig*.json	TypeScript necesita tsconfig.json para compilar