### PR TITLE
Resumen: Actualicé la atribución de puntajes para que los issues crea…

### DIFF
--- a/.github/workflows/puntajes_gestion.yml
+++ b/.github/workflows/puntajes_gestion.yml
@@ -14,11 +14,15 @@ on:
 jobs:
   registrar_puntaje_gestion:
     runs-on: ubuntu-latest
-    # Solo procesar si el actor es dgimenezdeveloper o folkodegroup
-    # Ignorar eventos generados por el propio bot (chore PRs)
+    # Ejecutar siempre para creación de issues (para acreditar al autor del issue).
+    # Para el resto de eventos limitar a los actores configurados y evitar PRs generados por el bot.
     if: |
-      (github.actor == 'dgimenezdeveloper' || github.actor == 'folkodegroup') &&
-      github.event.pull_request.head.ref != 'chore/gestion-puntaje-auto'
+      (
+        github.event_name == 'issues' && github.event.action == 'opened'
+      ) || (
+        (github.actor == 'dgimenezdeveloper' || github.actor == 'folkodegroup') &&
+        (github.event.pull_request == null || github.event.pull_request.head.ref != 'chore/gestion-puntaje-auto')
+      )
 
     steps:
       - name: Checkout code
@@ -38,10 +42,17 @@ jobs:
           github-token: ${{ secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const actor = context.actor;
-            // Siempre acreditar a dgimenezdeveloper (también cubre folkodegroup)
-            const devAcreditado = 'dgimenezdeveloper';
             const eventName = context.eventName;
             const payload = context.payload;
+
+            // Por defecto usar un fallback seguro
+            let devAcreditado = 'dgimenezdeveloper';
+
+            // Para creación de issues acreditar al creador real (mantener mapeo folkodegroup → dgimenezdeveloper)
+            if (eventName === 'issues' && payload.action === 'opened') {
+              const creator = payload.issue?.user?.login || actor || 'dgimenezdeveloper';
+              devAcreditado = (creator && creator.toLowerCase() === 'folkodegroup') ? 'dgimenezdeveloper' : creator;
+            }
 
             let puntaje = 0;
             let actividad = '';

--- a/frontend/scripts/generar_management_log.cjs
+++ b/frontend/scripts/generar_management_log.cjs
@@ -7,7 +7,7 @@
 //   - Reviews de PRs (aprobaciones, cambios solicitados, comentarios)
 //   - Milestones creados por dgimenezdeveloper/folkodegroup
 //   - Milestones cerrados (si el creador es dgimenezdeveloper/folkodegroup)
-//   - Issues creados por dgimenezdeveloper/folkodegroup
+//   - Issues creados (acreditados al creador; folkodegroup mapeado a dgimenezdeveloper)
 //   - Issues etiquetados por dgimenezdeveloper/folkodegroup
 //   - Issues asignados por dgimenezdeveloper/folkodegroup
 //
@@ -206,12 +206,13 @@ async function collectIssueEvents(entries) {
   const issues = await fetchAllPages('issues?state=all&filter=all');
   console.log(`    ${issues.length} issues encontrados`);
 
-  // Issues creados
+  // Issues creados — acreditar al creador de cada issue (folkodegroup → dgimenezdeveloper)
   for (const issue of issues) {
     if (issue.pull_request) continue; // saltar PRs que aparecen en /issues
-    if (!isTracked(issue.user?.login)) continue;
+    const creator = issue.user?.login;
+    if (!creator) continue;
     entries.push({
-      dev: normalizeDev(issue.user.login),
+      dev: normalizeDev(creator),
       score: 3,
       actividad: 'Creación de issue',
       referencia: `Issue #${issue.number}: ${issue.title}`,


### PR DESCRIPTION
…dos sean acreditados al creador del issue (manteniendo el mapeo folkodegroup → dgimenezdeveloper) y ajusté el generador semanal para no filtrar esas creaciones.

Modificado: puntajes_gestion.yml — permite ejecución para issues.opened de cualquier actor y en ese caso acredita el puntaje al creador del issue (con el mapeo folkodegroup→dgimenezdeveloper).

Modificado: generar_management_log.cjs — el recolector de issues ahora acredita la creación al autor del issue (en lugar de filtrar sólo usuarios rastreados), manteniendo el mapeo de alias.

Estado: Marqué las tareas relevantes como completadas en la lista de TODO interna.