### PR TITLE
descripcion en formulario de banners eliminado.

### DIFF
--- a/frontend/src/features/admin/banners/BannersAdmin.tsx
+++ b/frontend/src/features/admin/banners/BannersAdmin.tsx
@@ -22,7 +22,6 @@ import sectionStyles from '../shared/AdminSection.module.css';
 
 interface FormData {
   title: string;
-  description: string;
   imageFile: File | null;
   displayOrder: number;
   isActive: boolean;
@@ -37,7 +36,6 @@ export function BannersAdmin() {
   const [showForm, setShowForm] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     title: '',
-    description: '',
     imageFile: null,
     displayOrder: 0,
     isActive: true,
@@ -56,7 +54,6 @@ export function BannersAdmin() {
 
   const isDirty = showForm && (
     formData.title !== initialFormDataRef.current.title ||
-    formData.description !== initialFormDataRef.current.description ||
     formData.displayOrder !== initialFormDataRef.current.displayOrder ||
     formData.isActive !== initialFormDataRef.current.isActive ||
     formData.altText !== initialFormDataRef.current.altText ||
@@ -79,7 +76,7 @@ export function BannersAdmin() {
 
   function handleCancelForm() {
     interceptNavigation(() => {
-      setFormData({ title: '', description: '', imageFile: null, displayOrder: 0, isActive: true, altText: '' });
+      setFormData({ title: '', imageFile: null, displayOrder: 0, isActive: true, altText: '' });
       setEditingId(null);
       setShowForm(false);
     });
@@ -105,7 +102,6 @@ export function BannersAdmin() {
   function resetForm() {
     setFormData({
       title: '',
-      description: '',
       imageFile: null,
       displayOrder: 0,
       isActive: true,
@@ -126,7 +122,6 @@ export function BannersAdmin() {
     };
     setFormData({
       title: banner.title,
-      description: banner.description || '',
       imageFile: null,
       displayOrder: banner.displayOrder,
       isActive: banner.isActive,
@@ -166,7 +161,6 @@ export function BannersAdmin() {
       if (editingId) {
         await bannersAdminService.updateBanner(editingId, {
           title: formData.title,
-          description: formData.description,
           displayOrder: formData.displayOrder,
           isActive: formData.isActive,
           altText: formData.altText,
@@ -179,7 +173,6 @@ export function BannersAdmin() {
         await bannersAdminService.createBanner(
           {
             title: formData.title,
-            description: formData.description,
             displayOrder: formData.displayOrder,
             isActive: formData.isActive,
             altText: formData.altText,
@@ -286,17 +279,6 @@ export function BannersAdmin() {
                   {fieldErrors.title}
                 </span>
               )}
-            </div>
-
-            <div className={styles.formGroup}>
-              <label htmlFor="description">Descripción</label>
-              <textarea
-                id="description"
-                placeholder="Descripción opcional del banner"
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                rows={3}
-              />
             </div>
 
             <div className={styles.formGroup}>


### PR DESCRIPTION
descripcion en formulario de banners eliminado. Se eliminó el campo de descripción del formulario de creación y edición de banners, así como su manejo en el estado y en las funciones correspondientes.