### PR TITLE
Resumen de lo realizado

### DIFF
--- a/backend/migrations/022_create_suppliers.sql
+++ b/backend/migrations/022_create_suppliers.sql
@@ -1,0 +1,16 @@
+-- Crear tabla suppliers
+-- Tabla para gestionar proveedores comerciales
+
+CREATE TABLE IF NOT EXISTS suppliers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(255) NOT NULL,
+  url VARCHAR(500),
+  phone VARCHAR(50) NOT NULL,
+  address VARCHAR(500) NOT NULL,
+  products TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Índice en nombre para búsquedas rápidas
+CREATE INDEX idx_suppliers_name ON suppliers(name);


### PR DESCRIPTION
Problema encontrado:
El panel administrativo frontend tenía la vista de "Proveedores" completa Backend tenía rutas y servicio implementados para suppliers Prisma schema tenía el modelo Supplier definido
PERO: La tabla suppliers NO existía en la BD de la VPS ❌ Solución ejecutada:
Creé la migración SQL 022_create_suppliers.sql con:

Tabla suppliers con estructura correcta (UUID, name, url, phone, address, products) Índice en name para búsquedas rápidas
Campos de timestamp (created_at, updated_at)
Ejecuté la migración en ambas BD:

✅ BD local: migración aplicada correctamente
✅ BD VPS (tunnel): migración aplicada correctamente Regeneré el cliente de Prisma para que reconozca la tabla

Compilé el backend sin errores de TypeScript