### PR TITLE
fix en diseño de acciones rapidas en categorias

### DIFF
--- a/frontend/src/features/admin/categories/Categorylistpanel.module.css
+++ b/frontend/src/features/admin/categories/Categorylistpanel.module.css
@@ -90,7 +90,7 @@
     grid-template-columns: 40px 1fr;
     align-items: center;
     gap: var(--space-2);
-    padding: 8px 10px;
+    padding: .5rem .6rem;
 }
 
 /* ── Thumbnail ─────────────────────────────────────────────────── */
@@ -124,15 +124,14 @@
 .content {
     min-width: 0;
     display: flex;
-    flex-direction: column;
+    justify-content: space-between;
     margin-left: .5rem;
-    gap: 2px;
+    height: 60px;
 }
 
 .headerLine {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
     gap: var(--space-2);
 }
 
@@ -173,7 +172,7 @@
 /* ── Meta line ─────────────────────────────────────────────────── */
 .metaLine {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: space-between;
     gap: 5px;
     font-size: 11px;
@@ -212,7 +211,7 @@
     display: none;
     position: absolute;
     right: 8px;
-    top: 50%;
+    top: 30%;
     transform: translateY(-50%);
     gap: 4px;
     align-items: center;

--- a/frontend/src/features/admin/categories/Categorylistpanel.tsx
+++ b/frontend/src/features/admin/categories/Categorylistpanel.tsx
@@ -152,16 +152,17 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
                                     <div className={styles.content}>
                                         <div className={styles.headerLine}>
                                             <h3 className={styles.title}>{displayName}</h3>
+                                            <span className={styles.slug} title={`Slug: ${cat.slug}`}>
+                                                {cat.slug}
+                                            </span>
+
+                                        </div>
+
+                                        <div className={styles.metaLine}>
                                             <span
                                                 className={`${styles.visibilityBadge} ${cat.isVisible ? styles.visible : styles.hidden}`}
                                             >
                                                 {cat.isVisible ? 'Visible' : 'Oculta'}
-                                            </span>
-                                        </div>
-
-                                        <div className={styles.metaLine}>
-                                            <span className={styles.slug} title={`Slug: ${cat.slug}`}>
-                                                {cat.slug}
                                             </span>
                                             {productCount !== undefined && (
                                                 <>


### PR DESCRIPTION
ajusté el tamaño de los items de la lista para que sean más grandes y asi poder mostrar las acciones rapidas en la esquina superior derecha y el estado y cantidad de productos de esa categoria debajo