### PR TITLE
fix: actualizar workflow a Node.js 24 (evitar deprecation warnings)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,7 @@ on:
     branches: [main, develop]
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DOCKERHUB_USERNAME: dgimenezdeveloper
   BACKEND_IMAGE: dgimenezdeveloper/allmart-backend
   FRONTEND_IMAGE: dgimenezdeveloper/allmart-frontend
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          set-safe-directory: true
 
       - name: Escanear secretos con GitGuardian
         uses: GitGuardian/ggshield-action@v1
@@ -65,10 +67,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configurar Node.js 20
+      - name: Configurar Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
           cache-dependency-path: |
             frontend/package-lock.json
@@ -102,6 +104,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          set-safe-directory: true
 
       - name: Configurar Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,5 +24,13 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test/**"
+  ]
 }


### PR DESCRIPTION
- Agregar env var FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
- Cambiar Node.js de 20.x a 24.x en build-and-test job
- Agregar set-safe-directory en checkout actions
- Prepararse para deprecation de Node.js 20 (junio 2026)