### PR TITLE
fix url de etiqueta link en CartPage.tsx

### DIFF
--- a/frontend/src/pages/Cart/CartPage.tsx
+++ b/frontend/src/pages/Cart/CartPage.tsx
@@ -58,7 +58,7 @@ export function CartPage() {
         <ul className={styles.itemList} aria-label="Productos en el carrito">
           {items.map(({ product, quantity }) => (
             <li key={product.id} className={styles.item}>
-              <Link to={`/productos/${product.slug}`}>
+              <Link to={`/producto/${product.slug}`}>
                 <ProductImage
                   src={product.images[0]}
                   alt={product.name}
@@ -70,7 +70,7 @@ export function CartPage() {
               </Link>
 
               <div className={styles.itemInfo}>
-                <Link to={`/productos/${product.slug}`} className={styles.itemName}>
+                <Link to={`/producto/${product.slug}`} className={styles.itemName}>
                   {product.name}
                 </Link>
                 <span className={styles.itemCategory}>{product.category.name}</span>


### PR DESCRIPTION
El link en el archivo CartPage.tsx estaba apuntando hacia /productos/{product.slug} (que en realidad debería estar bien pero en algún lado se impuso que el detalle del producto se muestre en el endpoint /producto/{product.slug} o algo parecido) por lo que lo cambie a la url que funciona actualmente y muestra el detalle del producto la cual es /producto/{product.slug}