### PR TITLE
1096 subida de imágenes desde escritorio y gestión avanzada de imágenes en creaciónedición de combinaciones

### DIFF
--- a/backend/prisma/migrations/20260617133410_add_sku_image_storage/migration.sql
+++ b/backend/prisma/migrations/20260617133410_add_sku_image_storage/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "product_sku_images_storage" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "sku_id" UUID NOT NULL,
+    "data" BYTEA NOT NULL,
+    "width" INTEGER NOT NULL,
+    "height" INTEGER NOT NULL,
+    "thumbnail" BYTEA,
+    "thumb_width" INTEGER,
+    "thumb_height" INTEGER,
+    "mime_type" VARCHAR(50) NOT NULL DEFAULT 'image/webp',
+    "original_filename" VARCHAR(255),
+    "size_bytes" INTEGER NOT NULL,
+    "alt_text" VARCHAR(500),
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "is_primary" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "product_sku_images_storage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_product_sku_images_sku_id" ON "product_sku_images_storage"("sku_id");
+
+-- CreateIndex
+CREATE INDEX "idx_product_sku_images_position" ON "product_sku_images_storage"("sku_id", "position");
+
+-- CreateIndex
+CREATE INDEX "idx_collections_active_home" ON "collections"("display_position", "display_order") WHERE (is_active = true);
+
+-- AddForeignKey
+ALTER TABLE "product_sku_images_storage" ADD CONSTRAINT "product_sku_images_sku_fk" FOREIGN KEY ("sku_id") REFERENCES "product_skus"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -135,6 +135,31 @@ model ProductImageStorage {
   @@map("product_images_storage")
 }
 
+/// Imagen binaria asociada a una combinación / SKU de producto
+model ProductSkuImageStorage {
+  id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  skuId            String   @map("sku_id") @db.Uuid
+  data             Bytes
+  width            Int
+  height           Int
+  thumbnail        Bytes?
+  thumbWidth       Int?     @map("thumb_width")
+  thumbHeight      Int?     @map("thumb_height")
+  mimeType         String   @default("image/webp") @map("mime_type") @db.VarChar(50)
+  originalFilename String?  @map("original_filename") @db.VarChar(255)
+  sizeBytes        Int      @map("size_bytes")
+  altText          String?  @map("alt_text") @db.VarChar(500)
+  position         Int      @default(0)
+  isPrimary        Boolean  @default(false) @map("is_primary")
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  sku              ProductSku @relation(fields: [skuId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "product_sku_images_sku_fk")
+
+  @@index([skuId], map: "idx_product_sku_images_sku_id")
+  @@index([skuId, position], map: "idx_product_sku_images_position")
+  @@map("product_sku_images_storage")
+}
+
 /// Imagen de categoría almacenada en binario WebP (una por categoría)
 model CategoryImageStorage {
   id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
@@ -183,6 +208,7 @@ model ProductSku {
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   product    Product  @relation(fields: [productId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "product_skus_product_fk")
+  productSkuImages ProductSkuImageStorage[]
 
   @@index([productId], map: "idx_product_skus_product_id")
   @@map("product_skus")

--- a/backend/src/controllers/admin/skuImageController.ts
+++ b/backend/src/controllers/admin/skuImageController.ts
@@ -1,0 +1,58 @@
+import { Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../../types';
+import * as skuService from '../../services/productSkuImageService';
+import { sendSuccess } from '../../utils/response';
+
+export async function uploadSkuImage(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const { skuId } = req.params;
+        if (!req.file) {
+            res.status(400).json({ success: false, message: 'No file sent (field "image")' });
+            return;
+        }
+        const file = { buffer: req.file.buffer, originalname: req.file.originalname, mimetype: req.file.mimetype, size: req.file.size };
+        const image = await skuService.uploadSkuImage(skuId, file, req.body.altText, req.body.position !== undefined ? parseInt(req.body.position, 10) : undefined, req.body.isPrimary === 'true' || req.body.isPrimary === true);
+        sendSuccess(res, image, 201, 'SKU image uploaded');
+    } catch (err) {
+        next(err);
+    }
+}
+
+export async function listSkuImages(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const images = await skuService.getSkuImages(req.params.skuId);
+        sendSuccess(res, images);
+    } catch (err) {
+        next(err);
+    }
+}
+
+export async function showSkuImageMeta(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const meta = await skuService.getSkuImageMeta(req.params.id);
+        sendSuccess(res, meta);
+    } catch (err) {
+        next(err);
+    }
+}
+
+export async function updateSkuImageMeta(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const { altText, position, isPrimary } = req.body;
+        const normalizedPosition = position !== undefined ? parseInt(position, 10) : undefined;
+        const normalizedPrimary = isPrimary !== undefined ? Boolean(isPrimary) : undefined;
+        const meta = await skuService.updateSkuImageMeta(req.params.id, { altText, position: normalizedPosition, isPrimary: normalizedPrimary });
+        sendSuccess(res, meta, 200, 'SKU image meta updated');
+    } catch (err) {
+        next(err);
+    }
+}
+
+export async function deleteSkuImage(req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+        await skuService.deleteSkuImage(req.params.id);
+        sendSuccess(res, null, 200, 'SKU image deleted');
+    } catch (err) {
+        next(err);
+    }
+}

--- a/backend/src/controllers/public/skuImagePublicController.ts
+++ b/backend/src/controllers/public/skuImagePublicController.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import * as skuService from '../../services/productSkuImageService';
+
+export async function serveSkuImageThumb(req: Request, res: Response, next: NextFunction) {
+    try {
+        const { data, mimeType } = await skuService.serveSkuImageThumb(req.params.id);
+        res.set('Content-Type', mimeType);
+        res.set('Cache-Control', 'public, max-age=86400');
+        res.set('Content-Length', String(data.length));
+        res.send(data);
+    } catch (err) {
+        next(err);
+    }
+}
+
+export async function serveSkuImage(req: Request, res: Response, next: NextFunction) {
+    try {
+        const { data, mimeType } = await skuService.serveSkuImage(req.params.id);
+        res.set('Content-Type', mimeType);
+        res.set('Cache-Control', 'public, max-age=86400');
+        res.set('Content-Length', String(data.length));
+        res.send(data);
+    } catch (err) {
+        next(err);
+    }
+}

--- a/backend/src/routes/admin/products/skuImages.ts
+++ b/backend/src/routes/admin/products/skuImages.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { authMiddleware } from '../../../middlewares/auth';
+import { requireRole } from '../../../middlewares/permissions';
+import { UserRole } from '../../../types';
+import * as ctrl from '../../../controllers/admin/skuImageController';
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 8 * 1024 * 1024 } });
+
+const router = Router({ mergeParams: true });
+router.use(authMiddleware);
+
+router.post('/upload', requireRole(UserRole.ADMIN, UserRole.EDITOR), upload.single('image'), ctrl.uploadSkuImage);
+router.get('/', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.listSkuImages);
+router.get('/:id', requireRole(UserRole.ADMIN, UserRole.EDITOR), ctrl.showSkuImageMeta);
+router.patch('/:id/meta', requireRole(UserRole.ADMIN), ctrl.updateSkuImageMeta);
+router.delete('/:id', requireRole(UserRole.ADMIN), ctrl.deleteSkuImage);
+
+export default router;

--- a/backend/src/routes/admin/products/variants.ts
+++ b/backend/src/routes/admin/products/variants.ts
@@ -11,6 +11,7 @@ import { authMiddleware } from '../../../middlewares/auth';
 import { requireRole } from '../../../middlewares/permissions';
 import { UserRole } from '../../../types';
 import childrenRouter from './variants/children';
+import skuImagesRouter from './skuImages';
 
 const router = Router({ mergeParams: true }); // mergeParams para acceder a :productId
 
@@ -23,6 +24,9 @@ router.post('/', requireRole(UserRole.ADMIN), ctrl.create);
 // Mount this before the parameterized routes so the literal 'children' path isn't
 // captured by the ':variantId' route which would treat it as a UUID.
 router.use('/children', childrenRouter);
+
+// SKU images router mounted at /api/admin/products/:productId/skus/:skuId/images
+router.use('/skus/:skuId/images', skuImagesRouter);
 
 router.get('/:variantId', requireRole(UserRole.ADMIN), ctrl.show);
 router.put('/:variantId', requireRole(UserRole.ADMIN), ctrl.update);

--- a/backend/src/routes/public/images.ts
+++ b/backend/src/routes/public/images.ts
@@ -80,4 +80,9 @@ router.get('/categories/:id', async (req: Request, res: Response, next: NextFunc
 router.get('/banners/:id/thumb', bannersCtrl.getBannerThumbnail);
 router.get('/banners/:id', bannersCtrl.getBannerImage);
 
+// SKU images
+import * as skuPublic from '../../controllers/public/skuImagePublicController';
+router.get('/sku/:id/thumb', skuPublic.serveSkuImageThumb);
+router.get('/sku/:id', skuPublic.serveSkuImage);
+
 export default router;

--- a/backend/src/services/productSkuImageService.ts
+++ b/backend/src/services/productSkuImageService.ts
@@ -1,0 +1,128 @@
+import { prisma } from '../config/prisma';
+import { createError } from '../middlewares/errorHandler';
+
+// Reuse processImage and helpers from imageStorageService by importing directly
+// Note: imageStorageService exports helpers via functions but not processImage; we'll call its public API where possible.
+
+export interface UploadedImageFile {
+    buffer: Buffer;
+    originalname: string;
+    mimetype: string;
+    size: number;
+}
+
+// Placeholder for potential sync logic if product-level preview sync is required in future
+async function syncSkuImages(_skuId: string, _productId?: string) {
+    return;
+}
+
+export async function uploadSkuImage(
+    skuId: string,
+    file: UploadedImageFile,
+    altText?: string,
+    position?: number,
+    isPrimary?: boolean,
+) {
+    // Validate file using same rules as imageStorageService
+    // imageStorageService.validateFile is not exported; perform a lightweight validation here
+    const allowed = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp']);
+    if (!allowed.has(file.mimetype)) throw createError(`Tipo de archivo no permitido: ${file.mimetype}`, 400);
+    if (file.size > 8 * 1024 * 1024) throw createError('El archivo supera el tamaño máximo permitido de 8 MB', 400);
+
+    // Verify sku exists
+    const sku = await prisma.productSku.findUnique({ where: { id: skuId } });
+    if (!sku) throw createError('SKU no encontrado', 404);
+
+    if (position === undefined) {
+        const count = await prisma.productSkuImageStorage.count({ where: { skuId } });
+        position = count;
+    }
+
+    // Reuse image processing from imageStorageService by calling processImage via importing; but it's not exported -> use a simple conversion: store original buffer as-is and mark mimeType
+    // To avoid duplicating heavy logic, call imageStorageService.uploadProductImage? Not applicable. For now, store as-is without WebP conversion (safe fallback).
+    const created = await prisma.productSkuImageStorage.create({
+        data: {
+            skuId,
+            data: toBytes(file.buffer),
+            width: 0,
+            height: 0,
+            thumbnail: null,
+            thumbWidth: null,
+            thumbHeight: null,
+            mimeType: file.mimetype,
+            originalFilename: file.originalname,
+            sizeBytes: file.size,
+            altText: altText ?? null,
+            position,
+            isPrimary: Boolean(isPrimary ?? false),
+        },
+    });
+
+    if (created.isPrimary) {
+        // ensure only one primary per sku
+        await prisma.productSkuImageStorage.updateMany({ where: { skuId, id: { not: created.id } }, data: { isPrimary: false } });
+    }
+
+    await syncSkuImages(skuId, sku.productId);
+
+    return {
+        id: created.id,
+        skuId: created.skuId,
+        url: `/api/images/sku/${created.id}`,
+        thumbUrl: created.thumbnail ? `/api/images/sku/${created.id}/thumb` : undefined,
+        altText: created.altText,
+        position: created.position,
+        isPrimary: created.isPrimary,
+        createdAt: created.createdAt,
+        updatedAt: created.updatedAt,
+    };
+}
+
+export async function getSkuImages(skuId: string) {
+    const rows = await prisma.productSkuImageStorage.findMany({ where: { skuId }, orderBy: { position: 'asc' }, select: { id: true, skuId: true, altText: true, position: true, mimeType: true, originalFilename: true, sizeBytes: true, isPrimary: true, createdAt: true, updatedAt: true, thumbWidth: true, thumbHeight: true } });
+    return rows.map(r => ({ ...r, url: `/api/images/sku/${r.id}`, thumbUrl: r.thumbWidth ? `/api/images/sku/${r.id}/thumb` : undefined }));
+}
+
+export async function getSkuImageMeta(id: string) {
+    const row = await prisma.productSkuImageStorage.findUnique({ where: { id } });
+    if (!row) throw createError('Imagen no encontrada', 404);
+    return { ...row, url: `/api/images/sku/${row.id}`, thumbUrl: row.thumbWidth ? `/api/images/sku/${row.id}/thumb` : undefined };
+}
+
+export async function updateSkuImageMeta(id: string, data: { altText?: string | null; position?: number; isPrimary?: boolean }) {
+    const existing = await prisma.productSkuImageStorage.findUnique({ where: { id } });
+    if (!existing) throw createError('Imagen no encontrada', 404);
+    const updated = await prisma.productSkuImageStorage.update({ where: { id }, data: { altText: data.altText !== undefined ? data.altText : existing.altText, position: data.position !== undefined ? data.position : existing.position, isPrimary: data.isPrimary !== undefined ? data.isPrimary : existing.isPrimary }, select: { id: true, skuId: true, altText: true, position: true, isPrimary: true, createdAt: true, updatedAt: true, thumbWidth: true } });
+    if (updated.isPrimary) {
+        await prisma.productSkuImageStorage.updateMany({ where: { skuId: updated.skuId, id: { not: updated.id } }, data: { isPrimary: false } });
+    }
+    return { ...updated, url: `/api/images/sku/${updated.id}`, thumbUrl: updated.thumbWidth ? `/api/images/sku/${updated.id}/thumb` : undefined };
+}
+
+export async function deleteSkuImage(id: string) {
+    const existing = await prisma.productSkuImageStorage.findUnique({ where: { id } });
+    if (!existing) throw createError('Imagen no encontrada', 404);
+    await prisma.productSkuImageStorage.delete({ where: { id } });
+    // If deleted image was primary, assign another as primary if exists
+    if (existing.isPrimary) {
+        const next = await prisma.productSkuImageStorage.findFirst({ where: { skuId: existing.skuId }, orderBy: { position: 'asc' } });
+        if (next) await prisma.productSkuImageStorage.update({ where: { id: next.id }, data: { isPrimary: true } });
+    }
+}
+
+export async function serveSkuImage(id: string) {
+    const row = await prisma.productSkuImageStorage.findUnique({ where: { id }, select: { data: true, mimeType: true } });
+    if (!row) throw createError('Imagen no encontrada', 404);
+    return { data: Buffer.from(row.data), mimeType: row.mimeType };
+}
+
+export async function serveSkuImageThumb(id: string) {
+    const row = await prisma.productSkuImageStorage.findUnique({ where: { id }, select: { thumbnail: true, data: true, mimeType: true } });
+    if (!row) throw createError('Imagen no encontrada', 404);
+    const buffer = row.thumbnail ? Buffer.from(row.thumbnail) : Buffer.from(row.data);
+    return { data: buffer, mimeType: row.mimeType };
+}
+
+function toBytes(buf: Buffer): Uint8Array<ArrayBuffer> {
+    return new Uint8Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)) as Uint8Array<ArrayBuffer>;
+}

--- a/backend/src/services/productSkusService.ts
+++ b/backend/src/services/productSkusService.ts
@@ -96,11 +96,9 @@ export async function createSku(productId: string, dto: { sku?: string; attribut
         }
     }
     const attrsToSave = { ...(dto.attributes ?? {}) } as Record<string, any>;
-    const providedImages = (dto as any).images ?? attrsToSave.images;
-    if (!providedImages || (Array.isArray(providedImages) && providedImages.filter(Boolean).length === 0)) {
-        // If no images provided, reject creation
-        throw createError('La combinación debe incluir al menos una imagen', 400, ['images']);
-    }
+    // Images are optional at creation time. When present, merge into attributes.
+    // Images may be provided in dto.images or inside attributes; they will be merged below when present.
+    // (We intentionally do not enforce presence of images at create time.)
     // Merge images into attributes if provided in dto.images
     if ((dto as any).images && Array.isArray((dto as any).images)) {
         attrsToSave.images = (dto as any).images;

--- a/frontend/src/features/admin/images/AdminImages.module.css
+++ b/frontend/src/features/admin/images/AdminImages.module.css
@@ -65,7 +65,10 @@
   outline: none;
   transition: border-color 0.15s;
 }
-.searchInput:focus { border-color: var(--color-primary); }
+
+.searchInput:focus {
+  border-color: var(--color-primary);
+}
 
 .productList {
   list-style: none;
@@ -93,7 +96,11 @@
   transition: background 0.15s;
   border: 1px solid transparent;
 }
-.productItem:hover { background: var(--color-bg-secondary); }
+
+.productItem:hover {
+  background: var(--color-bg-secondary);
+}
+
 .productItem.selected {
   background: var(--color-bg-tertiary);
   border-color: var(--color-primary);
@@ -189,7 +196,10 @@
   overflow: hidden;
   transition: box-shadow 0.15s;
 }
-.imageCard:hover { box-shadow: 0 2px 10px rgba(0,0,0,0.08); }
+
+.imageCard:hover {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+}
 
 /* Thumbnail */
 .thumbnail {
@@ -222,7 +232,7 @@
   position: absolute;
   top: 6px;
   left: 6px;
-  background: rgba(0,0,0,0.55);
+  background: rgba(0, 0, 0, 0.55);
   color: var(--color-neutral-light);
   font-family: var(--font-ui);
   font-size: 10px;
@@ -285,8 +295,14 @@
   outline: none;
   transition: border-color 0.15s;
 }
-.editInput:focus { border-color: var(--color-primary); }
-.editInput::placeholder { color: var(--color-text-tertiary); }
+
+.editInput:focus {
+  border-color: var(--color-primary);
+}
+
+.editInput::placeholder {
+  color: var(--color-text-tertiary);
+}
 
 .inputError {
   border-color: var(--color-error) !important;
@@ -318,8 +334,15 @@
   transition: background 0.15s;
   flex-shrink: 0;
 }
-.saveBtn:hover:not(:disabled) { background: var(--color-primary-dark); }
-.saveBtn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.saveBtn:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+
+.saveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .cancelEditBtn {
   font-family: var(--font-ui);
@@ -332,7 +355,10 @@
   cursor: pointer;
   transition: border-color 0.15s;
 }
-.cancelEditBtn:hover { border-color: var(--color-text-secondary); }
+
+.cancelEditBtn:hover {
+  border-color: var(--color-text-secondary);
+}
 
 .editBtn {
   font-family: var(--font-ui);
@@ -345,7 +371,10 @@
   cursor: pointer;
   transition: background 0.15s;
 }
-.editBtn:hover { background: rgba(118,146,130,0.1); }
+
+.editBtn:hover {
+  background: rgba(118, 146, 130, 0.1);
+}
 
 .deleteBtn {
   font-family: var(--font-ui);
@@ -358,8 +387,15 @@
   cursor: pointer;
   transition: background 0.15s;
 }
-.deleteBtn:hover:not(:disabled) { background: rgba(192,57,43,0.07); }
-.deleteBtn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.deleteBtn:hover:not(:disabled) {
+  background: rgba(192, 57, 43, 0.07);
+}
+
+.deleteBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 /* ── Sección de agregar imagen ── */
 .addSection {
@@ -380,7 +416,10 @@
   cursor: pointer;
   transition: background 0.15s;
 }
-.addImageBtn:hover { background: var(--color-primary-dark); }
+
+.addImageBtn:hover {
+  background: var(--color-primary-dark);
+}
 
 .addForm {
   background: var(--color-bg-secondary);
@@ -450,7 +489,7 @@
   position: absolute;
   bottom: 5px;
   right: 5px;
-  background: rgba(0,0,0,0.45);
+  background: rgba(0, 0, 0, 0.45);
   color: var(--color-neutral-light);
   font-family: var(--font-ui);
   font-size: 9px;
@@ -481,13 +520,15 @@
   justify-content: center;
   background: var(--color-bg-primary);
 }
+
 .dropZone:hover {
   border-color: var(--color-primary);
-  background: rgba(118,146,130,0.04);
+  background: rgba(118, 146, 130, 0.04);
 }
+
 .dropZoneHasFile {
   border-color: var(--color-primary);
-  background: rgba(118,146,130,0.06);
+  background: rgba(118, 146, 130, 0.06);
   padding: var(--space-2);
   min-height: 160px;
 }
@@ -547,4 +588,134 @@
 
 .uploadErr {
   color: var(--color-error, #c0392b);
+}
+
+/* --- Small components for inline preview (used in variant modal) --- */
+.previewList {
+  max-width: 450px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 6px 0;
+}
+
+.previewItem {
+  position: relative;
+  width: 140px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-primary);
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.previewThumb {
+  width: 100%;
+  height: 90px;
+  background: var(--color-bg-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+.previewImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbPlaceholder {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.previewMeta {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.previewFileName {
+  /* filenames should not be visible */
+  display: none;
+}
+
+.previewActions {
+  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+}
+
+.progress {
+  width: 100%;
+}
+
+.retryBtn {
+  background: transparent;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+}
+
+.deleteBtn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: none;
+  background: rgba(0, 0, 0, 0.0);
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s, background 0.12s, color 0.12s;
+}
+
+
+
+.previewItem:hover .deleteBtn {
+  opacity: 1;
+  background: #f3f3f3;
+  color: var(--color-text-primary);
+}
+
+.previewItem:hover .deleteBtn:hover {
+  background: var(--color-bg-secondary);
+  ;
+  color: var(--color-primary);
+}
+
+.primaryBtn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.primaryActive {
+  background: rgba(118, 146, 130, 0.12);
+  /* subtle tint matching UI */
+  color: var(--color-primary);
+  border-color: rgba(118, 146, 130, 0.18);
+}
+
+.errorText {
+  color: var(--color-error);
+  font-size: var(--text-xs);
 }

--- a/frontend/src/features/admin/images/ImageItem.tsx
+++ b/frontend/src/features/admin/images/ImageItem.tsx
@@ -1,0 +1,31 @@
+import type { UploadFileState } from './useImageUpload';
+
+interface Props {
+    item: UploadFileState;
+    index: number;
+    onRemove: (id: string) => void;
+    onRetry: (id: string) => void;
+    onSetPrimary: (id: string) => void;
+}
+
+export default function ImageItem({ item, onRemove, onRetry, onSetPrimary }: Props) {
+    const src = item.previewUrl ?? item.remoteUrl ?? '';
+    return (
+        <div style={{ border: '1px solid #ddd', padding: 8, borderRadius: 6 }}>
+            <div style={{ height: 90, background: '#f6f6f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                {src ? <img src={src} alt={item.file?.name ?? item.remoteUrl} style={{ maxWidth: '100%', maxHeight: '100%' }} /> : <div>No preview</div>}
+            </div>
+            <div style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <small>{item.file?.name ?? (item.remoteUrl && item.remoteUrl.split('/').pop())}</small>
+                <button type="button" onClick={() => onRemove(item.uid)}>Eliminar</button>
+            </div>
+            <div style={{ marginTop: 6 }}>
+                {item.status === 'uploading' && <progress value={item.progress ?? 0} max={100} />}
+                {item.status === 'error' && <div style={{ color: 'red' }}>{item.errorMessage}<button onClick={() => onRetry(item.uid)}>Reintentar</button></div>}
+                <div style={{ marginTop: 6 }}>
+                    <button disabled={item.isPrimary} onClick={() => onSetPrimary(item.uid)}>{item.isPrimary ? 'Principal' : 'Marcar principal'}</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/admin/images/ImageItem.tsx
+++ b/frontend/src/features/admin/images/ImageItem.tsx
@@ -1,4 +1,5 @@
 import type { UploadFileState } from './useImageUpload';
+import styles from './AdminImages.module.css';
 
 interface Props {
     item: UploadFileState;
@@ -11,20 +12,26 @@ interface Props {
 export default function ImageItem({ item, onRemove, onRetry, onSetPrimary }: Props) {
     const src = item.previewUrl ?? item.remoteUrl ?? '';
     return (
-        <div style={{ border: '1px solid #ddd', padding: 8, borderRadius: 6 }}>
-            <div style={{ height: 90, background: '#f6f6f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                {src ? <img src={src} alt={item.file?.name ?? item.remoteUrl} style={{ maxWidth: '100%', maxHeight: '100%' }} /> : <div>No preview</div>}
+        <div className={styles.previewItem}>
+            <button type="button" title='Eliminar imagen' aria-label="Eliminar imagen" className={styles.deleteBtn} onClick={() => onRemove(item.uid)}>×</button>
+            <div className={styles.previewThumb}>
+                {src ? <img src={src} alt={item.file?.name ?? item.remoteUrl} className={styles.previewImg} /> : <div className={styles.thumbPlaceholder}>No preview</div>}
             </div>
-            <div style={{ marginTop: 6, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <small>{item.file?.name ?? (item.remoteUrl && item.remoteUrl.split('/').pop())}</small>
-                <button type="button" onClick={() => onRemove(item.uid)}>Eliminar</button>
-            </div>
-            <div style={{ marginTop: 6 }}>
-                {item.status === 'uploading' && <progress value={item.progress ?? 0} max={100} />}
-                {item.status === 'error' && <div style={{ color: 'red' }}>{item.errorMessage}<button onClick={() => onRetry(item.uid)}>Reintentar</button></div>}
-                <div style={{ marginTop: 6 }}>
-                    <button disabled={item.isPrimary} onClick={() => onSetPrimary(item.uid)}>{item.isPrimary ? 'Principal' : 'Marcar principal'}</button>
+
+            <div className={styles.previewMeta}>
+                <small className={styles.previewFileName}>{/* filename hidden per UI */}</small>
+                <div>
+                    {item.status === 'uploading' && <progress className={styles.progress} value={item.progress ?? 0} max={100} />}
+                    {item.status === 'error' && (
+                        <div className={styles.errorText}>{item.errorMessage} <button className={styles.retryBtn} onClick={() => onRetry(item.uid)}>Reintentar</button></div>
+                    )}
                 </div>
+            </div>
+
+            <div className={styles.previewActions}>
+                <button type="button" className={`${styles.primaryBtn} ${item.isPrimary ? styles.primaryActive : ''}`} disabled={item.isPrimary} onClick={() => onSetPrimary(item.uid)}>
+                    {item.isPrimary ? 'Principal' : 'Marcar principal'}
+                </button>
             </div>
         </div>
     );

--- a/frontend/src/features/admin/images/ImagePreviewList.tsx
+++ b/frontend/src/features/admin/images/ImagePreviewList.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import ImageItem from './ImageItem';
 import type { UploadFileState } from './useImageUpload';
+import styles from './AdminImages.module.css';
 
 interface Props {
     items: UploadFileState[];
@@ -11,7 +11,7 @@ interface Props {
 
 export default function ImagePreviewList({ items, onRemove, onRetry, onSetPrimary }: Props) {
     return (
-        <div style={{ display: 'flex', gap: 8, overflowX: 'auto' }}>
+        <div className={styles.previewList}>
             {items.map((it, idx) => (
                 <ImageItem key={it.uid} item={it} index={idx} onRemove={onRemove} onRetry={onRetry} onSetPrimary={onSetPrimary} />
             ))}

--- a/frontend/src/features/admin/images/ImagePreviewList.tsx
+++ b/frontend/src/features/admin/images/ImagePreviewList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ImageItem from './ImageItem';
+import type { UploadFileState } from './useImageUpload';
+
+interface Props {
+    items: UploadFileState[];
+    onRemove: (id: string) => void;
+    onRetry: (id: string) => void;
+    onSetPrimary: (id: string) => void;
+}
+
+export default function ImagePreviewList({ items, onRemove, onRetry, onSetPrimary }: Props) {
+    return (
+        <div style={{ display: 'flex', gap: 8, overflowX: 'auto' }}>
+            {items.map((it, idx) => (
+                <ImageItem key={it.uid} item={it} index={idx} onRemove={onRemove} onRetry={onRetry} onSetPrimary={onSetPrimary} />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/features/admin/images/ImageUploader.tsx
+++ b/frontend/src/features/admin/images/ImageUploader.tsx
@@ -1,0 +1,32 @@
+import React, { useRef } from 'react';
+
+interface Props {
+    multiple?: boolean;
+    maxSizeBytes?: number;
+    accept?: string[];
+    onAddFiles: (files: File[]) => void;
+}
+
+export default function ImageUploader({ multiple = true, maxSizeBytes = 5 * 1024 * 1024, accept = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'], onAddFiles }: Props) {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    function onFilesSelected(e: React.ChangeEvent<HTMLInputElement>) {
+        const list = e.target.files;
+        if (!list) return;
+        const arr = Array.from(list).filter(f => f.size <= maxSizeBytes && accept.includes(f.type));
+        if (arr.length) onAddFiles(arr);
+        // reset
+        if (inputRef.current) inputRef.current.value = '';
+    }
+
+    return (
+        <div style={{ border: '2px dashed #ccc', padding: 12, borderRadius: 6 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'column' }}>
+                <div>Arrastra y suelta imágenes aquí o selecciona archivos</div>
+                <div>
+                    <input ref={inputRef} type="file" multiple={multiple} accept={accept.join(',')} onChange={onFilesSelected} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/admin/images/index.ts
+++ b/frontend/src/features/admin/images/index.ts
@@ -1,2 +1,9 @@
 // Barrel — módulo de Imágenes
+export { default as ImageUploader } from './ImageUploader';
+export { default as ImagePreviewList } from './ImagePreviewList';
+export { default as ImageItem } from './ImageItem';
+export { useImageUpload } from './useImageUpload';
+export type { UploadFileState } from './useImageUpload';
+
+// legacy / higher-level admin UI (not part of the new uploader)
 export { AdminImages } from './AdminImages';

--- a/frontend/src/features/admin/images/skuImagesService.ts
+++ b/frontend/src/features/admin/images/skuImagesService.ts
@@ -20,16 +20,17 @@ export async function uploadSkuImage(token: string, productId: string, skuId: st
     if (altText !== undefined) form.append('altText', altText);
     if (position !== undefined) form.append('position', String(position));
     if (isPrimary !== undefined) form.append('isPrimary', String(isPrimary));
-    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/skus/${skuId}/images/upload`, { method: 'POST', body: form }, token);
+    // NOTE: backend mounts the SKU images router under /api/admin/products/:productId/variants/skus/:skuId/images
+    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/variants/skus/${skuId}/images/upload`, { method: 'POST', body: form }, token);
     return body.data;
 }
 
 export async function fetchSkuImages(token: string, productId: string, skuId: string): Promise<ApiSkuImage[]> {
-    const body = await apiFetch<ApiSuccess<ApiSkuImage[]>>(`/api/admin/products/${productId}/skus/${skuId}/images`, {}, token);
+    const body = await apiFetch<ApiSuccess<ApiSkuImage[]>>(`/api/admin/products/${productId}/variants/skus/${skuId}/images`, {}, token);
     return body.data ?? [];
 }
 
 export async function updateSkuImageMeta(token: string, productId: string, skuId: string, imageId: string, payload: { altText?: string | null; position?: number; isPrimary?: boolean }) {
-    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/skus/${skuId}/images/${imageId}/meta`, { method: 'PATCH', body: JSON.stringify(payload) }, token);
+    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/variants/skus/${skuId}/images/${imageId}/meta`, { method: 'PATCH', body: JSON.stringify(payload) }, token);
     return body.data;
 }

--- a/frontend/src/features/admin/images/skuImagesService.ts
+++ b/frontend/src/features/admin/images/skuImagesService.ts
@@ -1,0 +1,35 @@
+import { apiFetch } from '../../../utils/apiClient';
+
+interface ApiSuccess<T> { success: boolean; data: T; message?: string }
+
+export interface ApiSkuImage {
+    id: string;
+    skuId: string;
+    url: string;
+    thumbUrl?: string;
+    altText?: string | null;
+    position: number;
+    isPrimary?: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export async function uploadSkuImage(token: string, productId: string, skuId: string, file: File, altText?: string, position?: number, isPrimary?: boolean): Promise<ApiSkuImage> {
+    const form = new FormData();
+    form.append('image', file);
+    if (altText !== undefined) form.append('altText', altText);
+    if (position !== undefined) form.append('position', String(position));
+    if (isPrimary !== undefined) form.append('isPrimary', String(isPrimary));
+    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/skus/${skuId}/images/upload`, { method: 'POST', body: form }, token);
+    return body.data;
+}
+
+export async function fetchSkuImages(token: string, productId: string, skuId: string): Promise<ApiSkuImage[]> {
+    const body = await apiFetch<ApiSuccess<ApiSkuImage[]>>(`/api/admin/products/${productId}/skus/${skuId}/images`, {}, token);
+    return body.data ?? [];
+}
+
+export async function updateSkuImageMeta(token: string, productId: string, skuId: string, imageId: string, payload: { altText?: string | null; position?: number; isPrimary?: boolean }) {
+    const body = await apiFetch<ApiSuccess<ApiSkuImage>>(`/api/admin/products/${productId}/skus/${skuId}/images/${imageId}/meta`, { method: 'PATCH', body: JSON.stringify(payload) }, token);
+    return body.data;
+}

--- a/frontend/src/features/admin/images/useImageUpload.ts
+++ b/frontend/src/features/admin/images/useImageUpload.ts
@@ -1,0 +1,94 @@
+import { useState, useCallback } from 'react';
+import { uploadProductImage } from './productImagesService';
+import { uploadSkuImage } from './skuImagesService';
+
+export type UploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+export type UploadFileState = {
+    uid: string; // local id
+    file?: File; // present for local files
+    previewUrl?: string; // URL.createObjectURL
+    remoteUrl?: string; // returned by server
+    status: UploadStatus;
+    progress?: number;
+    errorMessage?: string | null;
+    id?: string; // remote db id
+    isPrimary?: boolean;
+}
+
+interface UseImageUploadOptions {
+    token: string;
+    productId: string;
+    skuId?: string;
+    maxSizeBytes?: number;
+}
+
+export function useImageUpload({ token, productId, skuId, maxSizeBytes = 5 * 1024 * 1024 }: UseImageUploadOptions) {
+    const [files, setFiles] = useState<UploadFileState[]>([]);
+
+    const addFiles = useCallback((incoming: File[]) => {
+        const filtered = incoming.filter(f => f.size <= maxSizeBytes);
+        const next = filtered.map(f => {
+            const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+            return { uid, file: f, previewUrl: URL.createObjectURL(f), status: 'pending' as UploadStatus, progress: 0 } as UploadFileState;
+        });
+        setFiles((s) => [...s, ...next]);
+    }, [maxSizeBytes]);
+
+    const remove = useCallback((uid: string) => {
+        setFiles((s) => s.filter(x => x.uid !== uid));
+    }, []);
+
+    const setPrimary = useCallback((uid: string) => {
+        setFiles((s) => s.map(x => ({ ...x, isPrimary: x.uid === uid })));
+    }, []);
+
+    const uploadAll = useCallback(async () => {
+        for (const f of files) {
+            if (f.status !== 'pending' || !f.file) continue;
+            try {
+                setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'uploading', progress: 10 } : x));
+                const res = skuId
+                    ? await uploadSkuImage(token ?? '', productId, skuId, f.file!)
+                    : await uploadProductImage(token ?? '', productId, f.file!);
+                setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'success', progress: 100, remoteUrl: res.url, id: res.id } : x));
+            } catch (err: unknown) {
+                let msg = 'Error';
+                if (err && typeof err === 'object' && 'message' in err) {
+                    const m = (err as { message?: unknown }).message;
+                    if (typeof m === 'string') msg = m;
+                }
+                setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'error', errorMessage: msg ?? 'Error', progress: 0 } : x));
+            }
+        }
+    }, [files, productId, token, skuId]);
+
+    const retry = useCallback(async (uid: string) => {
+        const f = files.find(x => x.uid === uid);
+        if (!f || !f.file) return;
+        setFiles(s => s.map(x => x.uid === uid ? { ...x, status: 'uploading', progress: 10, errorMessage: null } : x));
+        try {
+            const res = skuId
+                ? await uploadSkuImage(token ?? '', productId, skuId, f.file)
+                : await uploadProductImage(token ?? '', productId, f.file);
+            setFiles(s => s.map(x => x.uid === uid ? { ...x, status: 'success', progress: 100, remoteUrl: res.url, id: res.id } : x));
+        } catch (err: unknown) {
+            let msg = 'Error';
+            if (err && typeof err === 'object' && 'message' in err) {
+                const m = (err as { message?: unknown }).message;
+                if (typeof m === 'string') msg = m;
+            }
+            setFiles(s => s.map(x => x.uid === uid ? { ...x, status: 'error', errorMessage: msg ?? 'Error', progress: 0 } : x));
+        }
+    }, [files, productId, token, skuId]);
+
+    return {
+        files,
+        addFiles,
+        remove,
+        setPrimary,
+        uploadAll,
+        retry,
+        setFiles,
+    } as const;
+}

--- a/frontend/src/features/admin/images/useImageUpload.ts
+++ b/frontend/src/features/admin/images/useImageUpload.ts
@@ -43,15 +43,19 @@ export function useImageUpload({ token, productId, skuId, maxSizeBytes = 5 * 102
         setFiles((s) => s.map(x => ({ ...x, isPrimary: x.uid === uid })));
     }, []);
 
-    const uploadAll = useCallback(async () => {
+    type UploadResult = { uid: string; url?: string; id?: string; status: UploadStatus; errorMessage?: string | null };
+    const uploadAll = useCallback(async (overrideSkuId?: string): Promise<UploadResult[]> => {
+        const results: UploadResult[] = [];
+        const targetSku = overrideSkuId ?? skuId;
         for (const f of files) {
             if (f.status !== 'pending' || !f.file) continue;
             try {
                 setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'uploading', progress: 10 } : x));
-                const res = skuId
-                    ? await uploadSkuImage(token ?? '', productId, skuId, f.file!)
+                const res = targetSku
+                    ? await uploadSkuImage(token ?? '', productId, targetSku, f.file!)
                     : await uploadProductImage(token ?? '', productId, f.file!);
                 setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'success', progress: 100, remoteUrl: res.url, id: res.id } : x));
+                results.push({ uid: f.uid, url: res.url, id: res.id, status: 'success' });
             } catch (err: unknown) {
                 let msg = 'Error';
                 if (err && typeof err === 'object' && 'message' in err) {
@@ -59,8 +63,10 @@ export function useImageUpload({ token, productId, skuId, maxSizeBytes = 5 * 102
                     if (typeof m === 'string') msg = m;
                 }
                 setFiles(s => s.map(x => x.uid === f.uid ? { ...x, status: 'error', errorMessage: msg ?? 'Error', progress: 0 } : x));
+                results.push({ uid: f.uid, status: 'error', errorMessage: msg ?? 'Error' });
             }
         }
+        return results;
     }, [files, productId, token, skuId]);
 
     const retry = useCallback(async (uid: string) => {

--- a/frontend/src/features/admin/products/tabs/ProductDetailVariants.module.css
+++ b/frontend/src/features/admin/products/tabs/ProductDetailVariants.module.css
@@ -125,6 +125,12 @@
   background: var(--color-bg-primary);
 }
 
+.imageUploaderContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+}
+
 .modalActions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
+++ b/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
@@ -137,8 +137,19 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
   const [editingSkuId, setEditingSkuId] = useState<string | null>(null);
   // Image upload hook for combinations (product-level by default)
   const token = getStoredToken() ?? '';
-  const { files: uploadedFiles, addFiles, remove: removeFile, setPrimary, uploadAll, retry } = useImageUpload({ token, productId, skuId: editingSkuId ?? undefined });
-  const imagesProvidedViaUrls = Boolean(combinationImages.trim());
+  const { files: uploadedFiles, addFiles, remove: removeFile, setPrimary, uploadAll, retry, setFiles } = useImageUpload({ token, productId, skuId: editingSkuId ?? undefined });
+  // whether user manually provided URLs in the textarea
+  // (kept as a comment — validation is handled later after uploads)
+
+  // Ensure the first uploaded image is marked as primary by default
+  useEffect(() => {
+    if (!uploadedFiles || uploadedFiles.length === 0) return;
+    const hasPrimary = uploadedFiles.some(f => f.isPrimary);
+    if (!hasPrimary) {
+      const first = uploadedFiles[0];
+      if (first) setPrimary(first.uid);
+    }
+  }, [uploadedFiles, setPrimary]);
 
   useEffect(() => {
     if (product && product.sku) {
@@ -149,21 +160,40 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
 
   // Validate the current combination inputs and update combinationErrors
   const runCombinationValidation = useCallback(() => {
-    const result = validateCombination({ sku: combinationSku, skuBase: product?.sku, images: combinationImages, price: combinationPrice });
+    // If user provided newline URLs, pass them through. Otherwise, if there are uploaded files (local or remote),
+    // treat that as having images so validation passes.
+    let imagesInput: unknown = combinationImages;
+    if (!combinationImages.trim()) {
+      if (uploadedFiles && uploadedFiles.length > 0) {
+        // provide a non-empty array so validateCombination sees images present
+        imagesInput = uploadedFiles.map(f => f.remoteUrl ?? f.previewUrl ?? f.uid);
+      } else {
+        imagesInput = '';
+      }
+    }
+
+    const result = validateCombination({ sku: combinationSku, skuBase: product?.sku, images: imagesInput, price: combinationPrice });
     setCombinationErrors(result);
     return result;
-  }, [combinationSku, combinationImages, combinationPrice, product?.sku]);
+  }, [combinationSku, combinationImages, combinationPrice, product?.sku, uploadedFiles]);
 
   const openCombinationModal = () => {
-    // initialize attributes with first available value (if any)
+    // initialize attributes with empty values (no defaults)
     const initial: Record<string, string> = {};
     variants.forEach(v => {
-      initial[v.name] = v.values[0] ?? '';
+      initial[v.name] = '';
     });
     setCombinationAttrs(initial);
     setCombinationStock('');
     setCombinationImages('');
     setCombinationPrice('');
+    // ensure we are in create mode (no editing SKU) and clear any staged files
+    setEditingSkuId(null);
+    try {
+      setFiles([] as UploadFileState[]);
+    } catch {
+      // ignore if hook not available
+    }
     setCombinationModalOpen(true);
   };
 
@@ -187,33 +217,50 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
       return;
     }
 
-    // Upload any pending files first
-    await uploadAll();
-
-    // Business rule: require at least one image
-    const currentImagesCount = uploadedFiles.filter((f: UploadFileState) => f.status === 'success' || Boolean(f.remoteUrl)).length;
-    if (currentImagesCount === 0 && !imagesProvidedViaUrls) {
-      setCombinationErrors(prev => ({ ...prev, images: 'Se requiere al menos una imagen para la combinación' }));
-      return;
+    // Create or update SKU first (so we have an SKU id to upload files into storage if needed)
+    let persistedSkuId: string | undefined = undefined;
+    if (editingSkuId) {
+      await updateVariantChild(productId, editingSkuId, { sku: sku || undefined, attributes: attrs, stock, price });
+      persistedSkuId = editingSkuId;
+    } else {
+      const created = await createVariantChild(productId, { sku: sku || undefined, attributes: attrs, stock, price });
+      if (created && typeof created === 'object' && (created as Record<string, unknown>).id) {
+        persistedSkuId = String((created as Record<string, unknown>).id);
+      }
     }
 
+    // If we have a persisted SKU id, upload pending files into SKU storage and collect URLs
+    let uploadedRemoteUrls: string[] = [];
+    if (persistedSkuId) {
+      const results = await uploadAll(persistedSkuId);
+      uploadedRemoteUrls = results.filter(r => r.status === 'success' && r.url).map(r => r.url!) as string[];
+    }
+
+    // Combine any user-provided URLs with uploaded ones
+    if (images && Array.isArray(images)) {
+      images = [...uploadedRemoteUrls, ...images];
+    } else if (uploadedRemoteUrls.length > 0) {
+      images = uploadedRemoteUrls;
+    } else {
+      images = undefined;
+    }
+
+    // If we have a persisted SKU, ensure images are attached via updateVariantChild
     try {
-      if (editingSkuId) {
-        // update existing persisted SKU; server refresh will update list
-        await updateVariantChild(productId, editingSkuId, { sku: sku || undefined, attributes: attrs, stock, images, price });
-        setEditingSkuId(null);
+      if (persistedSkuId) {
+        // include attributes to avoid accidental overwrite on backend merge
+        await updateVariantChild(productId, persistedSkuId, { images, price, attributes: attrs });
+      } else if (!editingSkuId) {
+        // No persisted id returned — fall back to optimistic local entry
+        const newItem: CreatedCombination = { sku: sku || undefined, attributes: attrs, stock, images, price };
+        setCreatedCombinations(prev => [newItem, ...prev]);
       } else {
-        const created = await createVariantChild(productId, { sku: sku || undefined, attributes: attrs, stock, images, price });
-        // If backend returned a persisted object (with id), it will be present in `skus` after the context refresh.
-        // Only keep optimistic entry if backend didn't return an id.
-        const createdObj = created as CreatedCombination | undefined;
-        if (!(createdObj && createdObj.id)) {
-          const newItem: CreatedCombination = { sku: sku || undefined, attributes: attrs, stock, images, price };
-          setCreatedCombinations(prev => [newItem, ...prev]);
-        }
+        // Editing existing but no persistedSkuId (shouldn't happen) — still attempt to update
+        if (editingSkuId) await updateVariantChild(productId, editingSkuId, { images, price, attributes: attrs });
       }
     } finally {
       setCombinationModalOpen(false);
+      setEditingSkuId(null);
     }
   };
 
@@ -237,6 +284,13 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
     setCombinationPrice(typeof sku.price === 'number' ? sku.price : '');
     setCombinationImages(Array.isArray(sku.images) ? sku.images.join('\n') : '');
     setEditingSkuId(id);
+    // Prefill image previews from existing SKU images (remote URLs)
+    if (Array.isArray(sku.images) && sku.images.length > 0) {
+      const initial: UploadFileState[] = sku.images.map((url) => ({ uid: `remote-${Math.random().toString(36).slice(2, 8)}`, previewUrl: url, remoteUrl: url, status: 'success' } as UploadFileState));
+      setFiles(initial);
+    } else {
+      setFiles([] as UploadFileState[]);
+    }
     setCombinationModalOpen(true);
   };
 
@@ -296,7 +350,7 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
         {combinationModalOpen && (
           <div className={styles.modalBackdrop} role="dialog" aria-modal="true">
             <div className={styles.modal}>
-              <h3>Añadir combinación</h3>
+              <h3>{editingSkuId ? 'Editar combinación' : 'Añadir combinación'}</h3>
               {variants.length === 0 && <p className={styles.help}>No hay grupos de variantes para seleccionar.</p>}
               {variants.map((g) => (
                 <div key={g.id} className={styles.fieldRow}>
@@ -352,7 +406,7 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
               </div>
               <div className={styles.modalActions}>
                 <button type="button" onClick={() => setCombinationModalOpen(false)}>Cancelar</button>
-                <button type="button" onClick={handleCreateCombination} disabled={!!(combinationErrors.sku || combinationErrors.images || combinationErrors.price)}>Crear</button>
+                <button type="button" onClick={handleCreateCombination} disabled={!!(combinationErrors.sku || combinationErrors.images || combinationErrors.price)}>{editingSkuId ? 'Editar' : 'Crear'}</button>
               </div>
             </div>
           </div>
@@ -373,7 +427,8 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
               </div>
               {Array.isArray(s.images) && s.images.length > 0 && (
                 <div className={styles.combinationImages}>
-                  {s.images.map((img, i) => <img key={i} src={img} alt={s.sku ?? 'imagen'} className={styles.combinationThumb} />)}
+                  {/* Show only the first (primary) image for compact list view to avoid accumulated galleries */}
+                  <img src={s.images[0]} alt={s.sku ?? 'imagen'} className={styles.combinationThumb} />
                 </div>
               )}
               <div className={styles.combinationActions}>
@@ -396,7 +451,7 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
               </div>
               {Array.isArray(c.images) && c.images.length > 0 && (
                 <div className={styles.combinationImages}>
-                  {c.images.map((img, i) => <img key={i} src={img} alt={c.sku ?? 'imagen'} className={styles.combinationThumb} />)}
+                  <img src={c.images[0]} alt={c.sku ?? 'imagen'} className={styles.combinationThumb} />
                 </div>
               )}
             </div>

--- a/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
+++ b/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { validateCombination } from '../../../../utils/productFormUtils';
 import type { CombinationValidationErrors } from '../../../../utils/productFormUtils';
 import styles from './ProductDetailVariants.module.css';
+import { ImageUploader, ImagePreviewList, useImageUpload } from '../../images';
+import type { UploadFileState } from '../../images';
+import { getStoredToken } from '../../../../utils/apiClient';
 import { useAdminVariants } from '../../../../context/AdminVariantsContext';
 import { useAdminProducts } from '../../../../context/useAdminProductsContext';
 import { VariantGroupsGrid } from '../../variants/components/VariantGroupsGrid';
@@ -132,6 +135,10 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
   type CreatedCombination = { id?: string; sku?: string; attributes: Record<string, string>; stock?: number; images?: string[]; price?: number };
   const [createdCombinations, setCreatedCombinations] = useState<CreatedCombination[]>([]);
   const [editingSkuId, setEditingSkuId] = useState<string | null>(null);
+  // Image upload hook for combinations (product-level by default)
+  const token = getStoredToken() ?? '';
+  const { files: uploadedFiles, addFiles, remove: removeFile, setPrimary, uploadAll, retry } = useImageUpload({ token, productId, skuId: editingSkuId ?? undefined });
+  const imagesProvidedViaUrls = Boolean(combinationImages.trim());
 
   useEffect(() => {
     if (product && product.sku) {
@@ -177,6 +184,16 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
     const validation = runCombinationValidation();
     if (validation && (validation.sku || validation.images || validation.price)) {
       // keep modal open and show errors
+      return;
+    }
+
+    // Upload any pending files first
+    await uploadAll();
+
+    // Business rule: require at least one image
+    const currentImagesCount = uploadedFiles.filter((f: UploadFileState) => f.status === 'success' || Boolean(f.remoteUrl)).length;
+    if (currentImagesCount === 0 && !imagesProvidedViaUrls) {
+      setCombinationErrors(prev => ({ ...prev, images: 'Se requiere al menos una imagen para la combinación' }));
       return;
     }
 
@@ -306,19 +323,11 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
               </div>
               {combinationErrors.sku && <div className={styles.errorText}>{combinationErrors.sku}</div>}
               <div className={styles.fieldRow}>
-                <label htmlFor="combination-images">Imágenes (una URL por línea — recomendado)</label>
-                <textarea
-                  id="combination-images"
-                  placeholder="https://...\nhttps://..."
-                  rows={3}
-                  value={combinationImages}
-                  onChange={e => {
-                    setCombinationImages(e.target.value);
-                    runCombinationValidation();
-                  }}
-                  onBlur={() => runCombinationValidation()}
-                  className={combinationErrors.images ? styles.inputError : ''}
-                />
+                <label htmlFor="combination-images">Imágenes</label>
+                <div className={styles.imageUploaderContainer}>
+                  <ImageUploader onAddFiles={(f: File[]) => addFiles(f)} />
+                  <ImagePreviewList items={uploadedFiles} onRemove={(id: string) => removeFile(id)} onRetry={(id: string) => retry(id)} onSetPrimary={(id: string) => setPrimary(id)} />
+                </div>
               </div>
               {combinationErrors.images && <div className={styles.errorText}>{combinationErrors.images}</div>}
               <div className={styles.fieldRow}>

--- a/frontend/src/features/admin/variants/components/VariantEditModal.tsx
+++ b/frontend/src/features/admin/variants/components/VariantEditModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -25,6 +25,16 @@ export function VariantEditModal({ open, initialName, initialValues, onClose, on
   const [newValue, setNewValue] = useState('');
   const [error, setError] = useState('');
 
+  // Keep local state in sync when the modal is opened or the initial props change.
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setValues(initialValues);
+      setNewValue('');
+      setError('');
+    }
+  }, [open, initialName, initialValues]);
+
   const handleAddValue = () => {
     if (!newValue.trim()) return;
     if (values.includes(newValue.trim())) {
@@ -43,6 +53,10 @@ export function VariantEditModal({ open, initialName, initialValues, onClose, on
   const handleSave = () => {
     if (!name.trim()) {
       setError('El nombre es requerido');
+      return;
+    }
+    if (!values || values.length === 0) {
+      setError('Debe agregar al menos un valor');
       return;
     }
     onSave(name.trim(), values);

--- a/frontend/src/pages/ProductDetail/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetail/ProductDetailPage.tsx
@@ -49,12 +49,21 @@ export function ProductDetailPage() {
 
   const skuImages = useMemo(() => {
     // Si no hay variantes seleccionadas → siempre imágenes del producto base
-    if (Object.keys(selectedVariants).length === 0) return product?.images ?? [];
+    if (Object.keys(selectedVariants).length === 0) return (product?.images ?? []).filter(Boolean);
     // Si hay SKU seleccionado con imágenes propias → usarlas
-    if (selectedSku?.images && selectedSku.images.length > 0) return selectedSku.images;
-    // Fallback al producto base
-    return product?.images ?? [];
+    const source = (selectedSku?.images && selectedSku.images.length > 0) ? selectedSku.images : (product?.images ?? []);
+    // Normalize and deduplicate URLs to avoid duplicates showing in the gallery
+    const normalized = Array.isArray(source) ? source.map(String).filter(Boolean) : [];
+    const unique = Array.from(new Set(normalized));
+    return unique;
   }, [selectedSku, selectedVariants, product?.images]);
+
+  // Ensure selectedImage index stays in bounds when skuImages changes
+  useEffect(() => {
+    if (selectedImage >= (skuImages?.length ?? 0)) {
+      setSelectedImage(0);
+    }
+  }, [skuImages, selectedImage]);
   /* Cargar producto por slug */
   useEffect(() => {
     if (!slug) return;


### PR DESCRIPTION
Se reemplaza campo de subida de imagen por url a subida de imagen por subida desde el escritorio y previsualización, se requirió ajustar algunas cosas de validaciones y demás porque se rompían varias cosas, el funcionamiento actual es correcto pero posteriormente hay que validar mejor el formulario de subida de combinaciones