### PR TITLE
1152 icono de favorito en product cards y número del input de cantidad en detalle no visibles

### DIFF
--- a/frontend/src/features/products/ProductCard/ProductCard.module.css
+++ b/frontend/src/features/products/ProductCard/ProductCard.module.css
@@ -5,6 +5,7 @@
   align-items: center;
   gap: 4px;
 }
+
 .card {
   position: relative;
   display: flex;
@@ -147,7 +148,7 @@
 
 
 
-.badge{
+.badge {
   font-family: var(--font-ui);
   font-size: var(--text-sm);
   color: var(--color-text-primary);
@@ -194,13 +195,24 @@
   outline: 3px solid var(--color-accent-dark);
   outline-offset: 2px;
 }
+
 /* Estilo cuando el botón tiene la clase .activo */
 .activo {
   background-color: var(--color-primary);
   color: var(--color-neutral-light);
-  transform: scale(1.1); /* Un pequeño salto para que se note el click */
+  transform: scale(1.1);
+  /* Un pequeño salto para que se note el click */
   transition: var(--transition-fast);
   animation: heartBeat 0.4s linear;
+}
+
+
+.wishlistBtnIcon {
+  stroke: var(--color-text-primary);
+}
+
+.activo .wishlistBtnIcon {
+  stroke: none;
 }
 
 /* 4. La animación de "Latido" */
@@ -208,19 +220,24 @@
   0% {
     transform: scale(1);
   }
+
   25% {
     transform: scale(1.3);
   }
+
   50% {
     transform: scale(1);
   }
+
   75% {
     transform: scale(1.15);
   }
+
   100% {
     transform: scale(1);
   }
 }
+
 .body {
   display: flex;
   flex-direction: column;
@@ -299,7 +316,8 @@
   color: var(--color-soft-gray);
   text-decoration: line-through;
 }
-.exploreButton{
+
+.exploreButton {
   width: 90%;
   margin: auto;
   margin-bottom: var(--space-2);

--- a/frontend/src/features/products/ProductCard/ProductCard.tsx
+++ b/frontend/src/features/products/ProductCard/ProductCard.tsx
@@ -86,7 +86,7 @@ export function ProductCard({ product, variant = 'default' }: ProductCardProps) 
   }, [isFavorito, product, syncFavorite]);
 
 
-  const toggleFavorito = (e:React.MouseEvent) => {
+  const toggleFavorito = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     toggleFavorite(product);
@@ -197,7 +197,7 @@ export function ProductCard({ product, variant = 'default' }: ProductCardProps) 
           {isNew && <Badge variant="new">Nuevo</Badge>}
           {typeof product.stock === 'number' && isLowStock(product.stock, LOW_STOCK_THRESHOLD) && (
             <Badge className={`${styles.badge} ${styles.lowStockBadge}`}>
-              <AlertTriangle size={16} style={{marginRight: 4}} /> Stock bajo
+              <AlertTriangle size={16} style={{ marginRight: 4 }} /> Stock bajo
             </Badge>
           )}
         </div>
@@ -207,7 +207,8 @@ export function ProductCard({ product, variant = 'default' }: ProductCardProps) 
           type="button"
           onClick={toggleFavorito}
         >
-          <Heart size={18} fill={isFavorito ? 'currentColor' : 'transparent'} aria-hidden="true" />
+          <Heart size={18} stroke="currentColor"
+            strokeWidth={2} className={styles.wishlistBtnIcon} fill={isFavorito ? 'currentColor' : 'transparent'} aria-hidden="true" />
         </button>
       </div>
 
@@ -224,17 +225,17 @@ export function ProductCard({ product, variant = 'default' }: ProductCardProps) 
           <span>({product.reviewCount})</span>
         </div>
         <div className={styles.priceRow}>
-                {dynamicDiscount ? (
-                  <ProductPrice
-                    price={dynamicDiscount.finalPrice}
-                    size="md"
-                  />
-                ) : (
-                  <ProductPrice
-                    price={product.price}
-                    size="md"
-                  />
-                )}
+          {dynamicDiscount ? (
+            <ProductPrice
+              price={dynamicDiscount.finalPrice}
+              size="md"
+            />
+          ) : (
+            <ProductPrice
+              price={product.price}
+              size="md"
+            />
+          )}
         </div>
       </div>
       <Link

--- a/frontend/src/pages/ProductDetail/ProductDetailPage.module.css
+++ b/frontend/src/pages/ProductDetail/ProductDetailPage.module.css
@@ -582,8 +582,25 @@
   font-family: var(--font-ui);
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
   border: none;
   background: transparent;
+}
+
+.qtyValue:focus {
+  outline: none;
+  border: none;
+}
+
+/* Ocultar flechas de aumentar y disminuir en el input de cantidad de productos */
+.qtyValue::-webkit-outer-spin-button,
+.qtyValue::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.qtyValue {
+  -moz-appearance: textfield;
 }
 
 .buttonsRow {


### PR DESCRIPTION
Ajusté el icono de favoritos en las cards de productos en el home, ahora se ve el icono del corazon.
Ajusté el número de cantidad de productos en la vista del detalle del producto ahora es visible el número y el input ya no tiene estilos para el estado focus y no se renderizan las flechas de aumentar y disminuir que vienen por default del input type number