### PR TITLE
1119 quitar iconos y acciones innecesarias en la vista de producto del admin

### DIFF
--- a/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
+++ b/frontend/src/features/admin/products/tabs/ProductDetailVariants.tsx
@@ -25,7 +25,6 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
     addVariant,
     updateVariant,
     deleteVariant,
-    toggleVariantStatus,
     addValueToVariant,
     removeValueFromVariant,
     createVariantChild,
@@ -56,17 +55,6 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [productId]);
 
-  // Handlers para acciones inline
-  type VariantGroup = { name: string; values: string[] };
-  const handleDuplicate = async (group: VariantGroup) => {
-    const baseName = group.name + ' (Copia)';
-    let name = baseName;
-    let i = 2;
-    while (variants.some((v: VariantGroup) => v.name === name)) {
-      name = `${baseName} ${i++}`;
-    }
-    await addVariant(productId, name, group.values);
-  };
 
   const handleAddGroup = async () => {
     if (!newGroupName.trim()) {
@@ -89,10 +77,6 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
 
   const handleDelete = async (id: string) => {
     await deleteVariant(productId, id);
-  };
-
-  const handleToggleStatus = async (id: string, newStatus: boolean) => {
-    await toggleVariantStatus(productId, id, newStatus);
   };
 
   const handleAddValue = async (groupId: string, value: string) => {
@@ -399,7 +383,7 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
   const executeDeleteCombination = async () => {
     if (!productId || !skuToDeleteId) return;
     setDeleteConfirmOpen(false);
-    
+
     // Optimistic UI Update: Ocultar de inmediato en la tabla
     setDeletedSkuIds(prev => new Set([...prev, skuToDeleteId]));
 
@@ -446,9 +430,7 @@ export function ProductDetailVariants({ productId }: ProductDetailVariantsProps)
           groups={variants}
           onEditName={handleEditName}
           onDelete={handleDelete}
-          onDuplicate={handleDuplicate}
           onEditValue={handleEditValue}
-          onToggleStatus={handleToggleStatus}
           onAddValue={handleAddValue}
           onRemoveValue={handleRemoveValue}
           canEdit={true}

--- a/frontend/src/features/admin/variants/AdminVariants.tsx
+++ b/frontend/src/features/admin/variants/AdminVariants.tsx
@@ -20,7 +20,6 @@ import {
 } from './components';
 import { VariantsFilters } from './components/VariantFilters';
 import { useUnsavedChanges } from '../../../context/useUnsavedChanges';
-import type { VariantGroup } from '../../../context/AdminVariantsContext';
 
 export function AdminVariants() {
   // Estados para feedback UX
@@ -40,7 +39,6 @@ export function AdminVariants() {
     addVariant,
     updateVariant,
     deleteVariant,
-    toggleVariantStatus,
     addValueToVariant,
     removeValueFromVariant,
   } = useAdminVariants();
@@ -144,30 +142,6 @@ export function AdminVariants() {
   };
 
   // Nuevas funciones para edición avanzada
-  const handleDuplicateGroup = async (group: VariantGroup) => {
-    if (!selectedProductId) return;
-    const baseName = group.name + ' (Copia)';
-    let name = baseName;
-    let i = 2;
-    while (variants.some((v) => v.name === name)) {
-      name = `${baseName} ${i++}`;
-    }
-    try {
-      await addVariant(selectedProductId, name, group.values);
-      setNotif({ open: true, type: 'success', message: 'Variante duplicada correctamente.' });
-      const userEmail = user ?? 'desconocido';
-      logAdminActivity({
-        timestamp: new Date().toISOString(),
-        user: userEmail,
-        action: 'create',
-        entity: 'variant',
-        entityId: '', // Se generará en el backend
-        details: { productId: selectedProductId, name, baseGroupId: group.id },
-      });
-    } catch {
-      setNotif({ open: true, type: 'error', message: 'Error al duplicar variante.' });
-    }
-  };
 
   const handleOpenEditModal = (groupId: string) => {
     const group = variants.find((v) => v.id === groupId);
@@ -239,24 +213,6 @@ export function AdminVariants() {
       setNotif({ open: true, type: 'success', message: 'Valor editado correctamente.' });
     } catch {
       setNotif({ open: true, type: 'error', message: 'Error al editar valor.' });
-    }
-  };
-
-  const handleToggleStatus = async (variantId: string, newStatus: boolean) => {
-    if (!selectedProductId) return;
-    try {
-      await toggleVariantStatus(selectedProductId, variantId, newStatus);
-      const userEmail = user ?? 'desconocido';
-      logAdminActivity({
-        timestamp: new Date().toISOString(),
-        user: userEmail,
-        action: 'update',
-        entity: 'variant',
-        entityId: variantId,
-        details: { productId: selectedProductId, isActive: newStatus },
-      });
-    } catch {
-      setNotif({ open: true, type: 'error', message: 'Error al cambiar estado de variante.' });
     }
   };
 
@@ -380,7 +336,6 @@ export function AdminVariants() {
                   onEditName={handleEditGroupName}
                   onDelete={handleDeleteGroup}
                   onEditValue={handleEditValue}
-                  onToggleStatus={handleToggleStatus}
                   onAddValue={handleAddValue}
                   onRemoveValue={handleRemoveValue}
                   canEdit={can('variants.edit')}
@@ -390,7 +345,6 @@ export function AdminVariants() {
                   errors={errors}
                   isPendingNavigation={isDirty}
                   setIsDirty={setIsDirty}
-                  onDuplicate={handleDuplicateGroup}    // <-- PROP AGREGADA
                   onOpenEditModal={handleOpenEditModal}  // <-- PROP AGREGADA
                 />
               )}

--- a/frontend/src/features/admin/variants/components/CombinationTable.tsx
+++ b/frontend/src/features/admin/variants/components/CombinationTable.tsx
@@ -135,7 +135,7 @@ const RowMenu: React.FC<RowMenuProps> = ({ onEdit, onDelete }) => {
                         role="menuitem"
                         onClick={() => run(onEdit)}
                     >
-                        ✏️ Editar
+                        Editar
                     </button>
                     <div className={styles.dropdownDivider} />
                     <button
@@ -144,7 +144,7 @@ const RowMenu: React.FC<RowMenuProps> = ({ onEdit, onDelete }) => {
                         role="menuitem"
                         onClick={() => run(onDelete)}
                     >
-                        🗑️ Eliminar
+                        Eliminar
                     </button>
                 </div>,
                 document.body

--- a/frontend/src/features/admin/variants/components/VariantGroupCard.tsx
+++ b/frontend/src/features/admin/variants/components/VariantGroupCard.tsx
@@ -26,9 +26,7 @@ interface VariantGroupCardProps {
   group: VariantGroup;
   onEditName: (id: string, newName: string) => void;
   onDelete: (id: string) => void;
-  onDuplicate: (group: VariantGroup) => void;
   onEditValue: (groupId: string, oldValue: string, newValue: string) => void;
-  onToggleStatus: (id: string, newStatus: boolean) => void;
   onAddValue: (groupId: string, value: string) => void;
   onRemoveValue: (groupId: string, value: string) => void;
   canEdit: boolean;
@@ -49,7 +47,6 @@ export const VariantGroupCard: React.FC<VariantGroupCardProps> = ({
   onEditName,
   onDelete,
   onEditValue,
-  onToggleStatus,
   onAddValue,
   onRemoveValue,
   canEdit,
@@ -59,7 +56,6 @@ export const VariantGroupCard: React.FC<VariantGroupCardProps> = ({
   error,
   setIsDirty,
   onOpenEditModal, // Agregado para resolver error TS2304
-  onDuplicate      // Agregado para resolver error TS2304
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(group.name);
@@ -200,16 +196,6 @@ export const VariantGroupCard: React.FC<VariantGroupCardProps> = ({
 
           {menuOpen && (
             <div className={styles.actionsDropdown} role="menu">
-              {/* Toggle estado */}
-              <button
-                className={styles.dropdownItem}
-                type="button"
-                role="menuitem"
-                onClick={() => menuAction(() => onToggleStatus(group.id, !group.isActive))}
-              >
-                <span className={group.isActive ? styles.dotActive : styles.dotInactive} />
-                {group.isActive ? 'Desactivar variante' : 'Activar variante'}
-              </button>
 
               {/* Editar avanzado */}
               <button
@@ -218,17 +204,7 @@ export const VariantGroupCard: React.FC<VariantGroupCardProps> = ({
                 role="menuitem"
                 onClick={() => menuAction(() => onOpenEditModal(group.id))}
               >
-                🛠️ Editar (avanzado)
-              </button>
-
-              {/* Duplicar */}
-              <button
-                className={styles.dropdownItem}
-                type="button"
-                role="menuitem"
-                onClick={() => menuAction(() => onDuplicate(group))}
-              >
-                ⧉ Duplicar grupo
+                Editar (avanzado)
               </button>
 
               {/* Separador antes de eliminar */}
@@ -242,7 +218,7 @@ export const VariantGroupCard: React.FC<VariantGroupCardProps> = ({
                   role="menuitem"
                   onClick={() => menuAction(() => onDelete(group.id))}
                 >
-                  🗑️ Eliminar grupo
+                  Eliminar grupo
                 </button>
               )}
             </div>

--- a/frontend/src/features/admin/variants/components/VariantGroupsGrid.tsx
+++ b/frontend/src/features/admin/variants/components/VariantGroupsGrid.tsx
@@ -9,9 +9,7 @@ interface VariantGroupsGridProps {
   groups: VariantGroup[];
   onEditName: (id: string, newName: string) => void;
   onDelete: (id: string) => void;
-  onDuplicate: (group: VariantGroup) => void;
   onEditValue: (groupId: string, oldValue: string, newValue: string) => void;
-  onToggleStatus: (id: string, newStatus: boolean) => void;
   onAddValue: (groupId: string, value: string) => void;
   onRemoveValue: (groupId: string, value: string) => void;
   canEdit: boolean;
@@ -32,7 +30,6 @@ export const VariantGroupsGrid: React.FC<VariantGroupsGridProps> = ({
   onEditName,
   onDelete,
   onEditValue,
-  onToggleStatus,
   onAddValue,
   onRemoveValue,
   canEdit,
@@ -42,7 +39,6 @@ export const VariantGroupsGrid: React.FC<VariantGroupsGridProps> = ({
   errors,
   isPendingNavigation,
   setIsDirty,
-  onDuplicate,      // Agregado para resolver error TS2304
   onOpenEditModal,  // Agregado para resolver error TS2304
 }) => {
 
@@ -68,9 +64,7 @@ export const VariantGroupsGrid: React.FC<VariantGroupsGridProps> = ({
             group={group}
             onEditName={onEditName}
             onDelete={onDelete}
-            onDuplicate={onDuplicate}
             onEditValue={onEditValue}
-            onToggleStatus={onToggleStatus}
             onAddValue={onAddValue}
             onRemoveValue={onRemoveValue}
             canEdit={canEdit}


### PR DESCRIPTION
Eliminé las acciones duplicate y activar/desactivar de las cards de variantes, eliminé iconos de las mismas cards y también los iconos de las acciones de las celdas de las combinaciones Editar y Eliminar