### PR TITLE
Eliminación de iconos y algunos ajustes de centrado en headers de la tabla de pedidos en ver

### DIFF
--- a/frontend/src/features/admin/orders/AdminOrders.module.css
+++ b/frontend/src/features/admin/orders/AdminOrders.module.css
@@ -316,7 +316,7 @@
 }
 
 .searchInput:focus,
-.searchInput:hover{
+.searchInput:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -386,7 +386,7 @@
 }
 
 .filterSelect:focus,
-.filterSelect:hover{
+.filterSelect:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -487,7 +487,7 @@
 }
 
 .dateInput:focus,
-.dateInput:hover{
+.dateInput:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -522,7 +522,7 @@
 }
 
 .totalInput:focus,
-.totalInput:hover{
+.totalInput:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -638,8 +638,8 @@
   padding: 16px 20px;
 }
 
-.tdEmail{
-  color: var(--color-normal-gray) ;
+.tdEmail {
+  color: var(--color-normal-gray);
   font-size: 0.8rem;
 }
 
@@ -1915,7 +1915,7 @@
   width: 120px;
 }
 
-.customerTd{
+.customerTd {
   font-weight: 600;
   font-size: 16px;
   color: var(--color-text-primary);
@@ -1995,3 +1995,13 @@
   }
 }
 
+.orderStatusSelectorContainer {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5em;
+}
+
+.statusConfirmActions {
+  display: flex;
+  gap: var(--space-3);
+}

--- a/frontend/src/features/admin/orders/AdminOrders.tsx
+++ b/frontend/src/features/admin/orders/AdminOrders.tsx
@@ -338,32 +338,26 @@ function AdminOrders() {
         ) : (
           <>
             <div className={`${styles.summaryCard} ${styles.cardTotal}`}>
-              <span className={styles.summaryIcon}>🛒</span>
               <span className={styles.summaryNum}>{orders.length}</span>
               <span className={styles.summaryLabel}>Total pedidos</span>
             </div>
             <div className={`${styles.summaryCard} ${styles.cardPendiente}`}>
-              <span className={styles.summaryIcon}>⏳</span>
               <span className={`${styles.summaryNum} ${styles.numPendiente}`}>{summary.pendiente}</span>
               <span className={styles.summaryLabel}>Pendientes</span>
             </div>
             <div className={`${styles.summaryCard} ${styles.cardPreparacion}`}>
-              <span className={styles.summaryIcon}>🔧</span>
               <span className={`${styles.summaryNum} ${styles.numPreparacion}`}>{summary['en-preparacion']}</span>
               <span className={styles.summaryLabel}>En preparación</span>
             </div>
             <div className={`${styles.summaryCard} ${styles.cardEnviado}`}>
-              <span className={styles.summaryIcon}>🚚</span>
               <span className={`${styles.summaryNum} ${styles.numEnviado}`}>{summary.enviado}</span>
               <span className={styles.summaryLabel}>Enviados</span>
             </div>
             <div className={`${styles.summaryCard} ${styles.cardEntregado}`}>
-              <span className={styles.summaryIcon}>✅</span>
               <span className={`${styles.summaryNum} ${styles.numEntregado}`}>{summary.entregado}</span>
               <span className={styles.summaryLabel}>Entregados</span>
             </div>
             <div className={`${styles.summaryCard} ${styles.cardAbonado}`}>
-              <span className={styles.summaryIcon}>💬</span>
               <span className={`${styles.summaryNum} ${styles.numAbonado}`}>{totalAbonados}</span>
               <span className={styles.summaryLabel}>Abonados</span>
             </div>

--- a/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
+++ b/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
@@ -28,6 +28,7 @@
     opacity: 0;
     transform: translateY(8px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -55,7 +56,7 @@
 
 .statusRow {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 1rem;
   flex-wrap: wrap;
 }
@@ -76,8 +77,8 @@
   gap: 1rem;
   margin-top: 1rem;
   padding: 1rem;
-  background: #f0fdf4;
-  border: 1px solid #dcfce7;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
 }
 
@@ -85,10 +86,10 @@
   font-family: inherit;
   font-size: 0.95rem;
   padding: 0.75rem;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: white;
-  color: #1a1a1a;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
   outline: none;
   transition: border-color 0.2s ease;
 }
@@ -336,7 +337,6 @@
 }
 
 .itemsTable th {
-  text-align: left;
   padding: 0.75rem 1rem;
   font-weight: 800;
   color: var(--color-text-tertiary);
@@ -354,6 +354,10 @@
 
 .itemsTable tbody tr:hover {
   background: var(--color-bg-secondary) !important;
+}
+
+.tdLeft {
+  text-align: left;
 }
 
 .tdCenter {

--- a/frontend/src/features/admin/orders/components/OrderDetailContent.tsx
+++ b/frontend/src/features/admin/orders/components/OrderDetailContent.tsx
@@ -217,7 +217,6 @@ export const OrderDetailContent = ({ order, onClose }: OrderDetailContentProps) 
                   type="button"
                   onClick={() => setConfirmPaid(true)}
                 >
-                  <span className={styles.whatsappIcon}>💬</span>
                   Marcar como abonado
                 </button>
               ) : (
@@ -273,7 +272,7 @@ export const OrderDetailContent = ({ order, onClose }: OrderDetailContentProps) 
         <table className={styles.itemsTable}>
           <thead>
             <tr>
-              <th>Producto</th>
+              <th className={styles.tdLeft}>Producto</th>
               <th className={styles.tdCenter}>Cant.</th>
               <th className={styles.tdRight}>P. unit.</th>
               <th className={styles.tdRight}>Subtotal</th>
@@ -332,7 +331,7 @@ export const OrderDetailContent = ({ order, onClose }: OrderDetailContentProps) 
                   onClick={() => setConfirmDelete(true)}
                   aria-label="Eliminar pedido"
                 >
-                  🗑️ Eliminar este pedido
+                  Eliminar este pedido
                 </button>
               </Tooltip>
             ) : (

--- a/frontend/src/features/admin/orders/components/OrderStatusSelector.tsx
+++ b/frontend/src/features/admin/orders/components/OrderStatusSelector.tsx
@@ -43,9 +43,8 @@ interface OrderStatusSelectorProps {
  * de persistir el cambio recae en el padre (OrderItem, OrderDetailModal).
  */
 
-export const OrderStatusSelector: React.FC<OrderStatusSelectorProps> = ({ value, onChange, disabled, className }) => {
+export const OrderStatusSelector: React.FC<OrderStatusSelectorProps> = ({ value, onChange, disabled }) => {
   // Estado local para el valor "en vuelo" antes de confirmar
-  const [showConfirm, setShowConfirm] = useState(false);
   const [pendingStatus, setPendingStatus] = useState<OrderStatus>(value);
 
   /**
@@ -57,29 +56,13 @@ export const OrderStatusSelector: React.FC<OrderStatusSelectorProps> = ({ value,
   const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = e.target.value as OrderStatus;
     setPendingStatus(newStatus);
-    setShowConfirm(true);
 
     // Notificación optimista: el padre puede marcar isDirty sin esperar confirmación
     if (newStatus !== value) onChange(newStatus);
   };
 
-  /** El usuario confirmó el cambio: solo cerramos el cuadro. El padre ya tiene el valor. */
-  const handleConfirm = () => {
-    setShowConfirm(false);
-  };
-
-  /**
-  * El usuario canceló: revertimos el estado local Y notificamos al padre
-  * para que también revierta (ej: limpiar isDirty si no hay otros cambios).
-  */
-  const handleCancel = () => {
-    setPendingStatus(value);
-    setShowConfirm(false);
-    onChange(value); // revierte en el padre
-  };
-
   return (
-    <div className={className} style={{ display: 'inline-block', position: 'relative' }}>
+    <div className={styles.orderStatusSelectorContainer}>
       <select
         className={styles.statusSelect}
         value={pendingStatus}
@@ -91,23 +74,6 @@ export const OrderStatusSelector: React.FC<OrderStatusSelectorProps> = ({ value,
           <option key={s} value={s}>{STATUS_LABELS[s]}</option>
         ))}
       </select>
-
-      {/* Cuadro de confirmación inline: aparece debajo del select tras un cambio */}
-      {showConfirm && (
-        <div className={styles.statusConfirmBox}>
-          <span className={styles.statusConfirmText}>
-            ¿Confirmar cambio de estado a "{STATUS_LABELS[pendingStatus as keyof typeof STATUS_LABELS]}"?
-          </span>
-          <div className={styles.statusConfirmActions}>
-            <button className={styles.applyStatusBtn} type="button" onClick={handleConfirm}>
-              Confirmar
-            </button>
-            <button className={styles.cancelBtn} type="button" onClick={handleCancel}>
-              Cancelar
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/features/admin/orders/components/OrdersHeader.tsx
+++ b/frontend/src/features/admin/orders/components/OrdersHeader.tsx
@@ -25,7 +25,7 @@ export function OrdersHeader() {
       {/* Etiqueta de sección (breadcrumb visual) */}
       <span className={sectionStyles.label}>Administración</span>
       <h1 className={sectionStyles.title}>
-        <span className={sectionStyles.icon}>🛒</span> Pedidos
+        Pedidos
         {/*
           Botón de ayuda: abre un Tooltip con descripción de la sección.
           El botón está vacío visualmente; el contenido lo provee el Tooltip.

--- a/frontend/src/features/admin/orders/pages/OrderDetailPage.tsx
+++ b/frontend/src/features/admin/orders/pages/OrderDetailPage.tsx
@@ -150,17 +150,14 @@ export default function OrderDetailPage() {
             </h1>
             <div className={styles.headerMeta}>
               <span className={styles.metaItem}>
-                <span className={styles.metaIcon}>📅</span>
                 {formatDateTime(order.createdAt)}
               </span>
               <span className={styles.metaDivider}>•</span>
               <span className={styles.metaItem}>
-                <span className={styles.metaIcon}>💰</span>
                 {formatPrice(order.total)}
               </span>
               <span className={styles.metaDivider}>•</span>
               <span className={styles.metaItem}>
-                <span className={styles.metaIcon}>📦</span>
                 {order.items.length} producto{order.items.length !== 1 ? 's' : ''}
               </span>
             </div>


### PR DESCRIPTION
Eliminé iconos emojis de la vista de pedidos en la vista de pedidos y ajusté estilos, eliminé el modal de confirmación al cambiar el estado del pedido ya que se renderizaban 2 con la misma funcionalidad, eliminé el pequeño y dejé el grande que pide una descripción no obligatoria.