### PR TITLE
ajuste de columnas en la vista de categorias

### DIFF
--- a/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
+++ b/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
@@ -2,7 +2,8 @@
    Mirrors MasterDetailLayout.module.css — same two-column structure. */
 
 .container {
-    display: flex;
+    display: grid;
+    grid-template-columns: 40% 60%;
     width: 100%;
     min-height: 500px;
     border: 1px solid var(--color-border, #e5e2dd);
@@ -65,4 +66,3 @@
         height: 300px;
     }
 }
-


### PR DESCRIPTION
Cambie el display flex del contenedor de los dos paneles a display grid con el mismo porcentaje de espacio que tienen las de productos, se renderiza bien el mensaje de categoria no encontrada
