### PR TITLE
Cambio implementado y verificado.

### DIFF
--- a/frontend/src/features/admin/promotions/AdminPromotionForm.tsx
+++ b/frontend/src/features/admin/promotions/AdminPromotionForm.tsx
@@ -197,6 +197,20 @@ const AdminPromotionForm: React.FC<Props> = ({ promotion, onSubmit, onCancel }) 
     setValueError(error);
   }, [value, type, validateValue]);
 
+  // ─── Force BOGO value ───────────────────────────────────────────────────────
+  useEffect(() => {
+    if (type === 'bogo' && value !== '0') {
+      setValue('0');
+    }
+  }, [type, value]);
+
+  const handleTypeChange = useCallback((newType: Promotion['type']) => {
+    setType(newType);
+    if (newType === 'bogo') {
+      setValue('0');
+    }
+  }, []);
+
   // ─── Handlers ────────────────────────────────────────────────────────────
   function toggleProduct(id: string) {
     setSelectedProductIds((prev) =>
@@ -304,7 +318,7 @@ const AdminPromotionForm: React.FC<Props> = ({ promotion, onSubmit, onCancel }) 
             <div className={styles.formRow}>
               <div className={styles.formGroup}>
                 <label htmlFor="promo-type">Tipo de Descuento *</label>
-                <select id="promo-type" value={type} onChange={(e) => setType(e.target.value as Promotion['type'])}>
+                <select id="promo-type" value={type} onChange={(e) => handleTypeChange(e.target.value as Promotion['type'])}>
                   {Object.entries(TYPE_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
                 </select>
               </div>

--- a/frontend/src/features/admin/promotions/__tests__/AdminPromotionForm.test.tsx
+++ b/frontend/src/features/admin/promotions/__tests__/AdminPromotionForm.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import AdminPromotionForm from '../AdminPromotionForm';
+import { AdminAuthProvider } from '../../../../context/AdminAuthContext';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useBlocker: vi.fn().mockReturnValue({ state: 'unblocked', proceed: vi.fn(), reset: vi.fn() }),
+  };
+});
+
+vi.mock('../../../../utils/apiClient', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ data: { data: [] } }),
+}));
+
+vi.mock('../../categories/categoriesService', () => ({
+  fetchAdminCategories: vi.fn().mockResolvedValue({ data: [] }),
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <AdminAuthProvider>{children}</AdminAuthProvider>
+);
+
+const defaultProps = {
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('AdminPromotionForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reset value to 0 when BOGO type is selected', () => {
+    render(
+      <Wrapper>
+        <AdminPromotionForm {...defaultProps} />
+      </Wrapper>
+    );
+
+    const typeSelect = screen.getByLabelText('Tipo de Descuento *');
+    const valueInput = screen.getByLabelText('Valor *') as HTMLInputElement;
+
+    fireEvent.change(typeSelect, { target: { value: 'fixed' } });
+    fireEvent.change(valueInput, { target: { value: '50' } });
+    expect(valueInput.value).toBe('50');
+
+    fireEvent.change(typeSelect, { target: { value: 'bogo' } });
+    expect(valueInput.value).toBe('0');
+  });
+});


### PR DESCRIPTION
Qué se actualizó
AdminPromotionForm.tsx

Ahora el campo Valor se fuerza a 0 cuando el usuario selecciona el tipo BOGO. Esto evita que quede el valor anterior de otro tipo de descuento. AdminPromotionForm.test.tsx

Añadí un test que verifica:
seleccionar fixed
ingresar 50
cambiar a bogo
el campo Valor se actualiza inmediatamente a 0
Resultado
Cumple con el comportamiento esperado:
Valor se establece automáticamente en 0
No conserva valores anteriores
UI refleja el cambio de forma inmediata