### PR TITLE
Quitar las celdas "Estados / Cliente / Producto" del PDF detallado de Reportes

### DIFF
--- a/frontend/src/features/admin/reports/AdminReports.tsx
+++ b/frontend/src/features/admin/reports/AdminReports.tsx
@@ -532,7 +532,6 @@ export function AdminReports() {
               statusSlices={statusSlices}
               periodLabel={filters.type === 'predefined' ? PERIOD_LABELS[filters.period] : 'Rango personalizado'}
               ordersTableProps={{ orders: filteredOrdersTable }}
-              ordersTableFilters={ordersTableFilters}
             />
           </div>
         )}
@@ -704,41 +703,41 @@ export function AdminReports() {
               <label className={styles.advancedLabel}>
                 <strong>Cliente</strong>
                 <div className={styles.searchWrap}>
-                <Search size={16} className={styles.searchIcon} />
-                <input
-                  type="text"
-                  value={ordersTableFilters.clientQuery}
-                  onChange={e => {
-                    e.preventDefault();
-                    setOrdersTableFilters(f => ({ ...f, clientQuery: e.target.value }))
-                  }}
-                  placeholder="Nombre o email"
-                  className={styles.advancedInput}
-                  autoComplete="off"
-                  spellCheck="false"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                />
+                  <Search size={16} className={styles.searchIcon} />
+                  <input
+                    type="text"
+                    value={ordersTableFilters.clientQuery}
+                    onChange={e => {
+                      e.preventDefault();
+                      setOrdersTableFilters(f => ({ ...f, clientQuery: e.target.value }))
+                    }}
+                    placeholder="Nombre o email"
+                    className={styles.advancedInput}
+                    autoComplete="off"
+                    spellCheck="false"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                  />
                 </div>
               </label>
               <label className={styles.advancedLabel}>
                 <strong>Producto</strong>
                 <div className={styles.searchWrap}>
-                <Search size={16} className={styles.searchIcon} />
-                <input
-                  type="text"
-                  value={ordersTableFilters.productQuery}
-                  onChange={e => {
-                    e.preventDefault();
-                    setOrdersTableFilters(f => ({ ...f, productQuery: e.target.value }))
-                  }}
-                  placeholder="Nombre de producto"
-                  className={styles.advancedInput}
-                  autoComplete="off"
-                  spellCheck="false"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                />
+                  <Search size={16} className={styles.searchIcon} />
+                  <input
+                    type="text"
+                    value={ordersTableFilters.productQuery}
+                    onChange={e => {
+                      e.preventDefault();
+                      setOrdersTableFilters(f => ({ ...f, productQuery: e.target.value }))
+                    }}
+                    placeholder="Nombre de producto"
+                    className={styles.advancedInput}
+                    autoComplete="off"
+                    spellCheck="false"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                  />
                 </div>
               </label>
               <OrdersFilters

--- a/frontend/src/features/admin/reports/PrintableReport.tsx
+++ b/frontend/src/features/admin/reports/PrintableReport.tsx
@@ -19,10 +19,10 @@ export interface PrintableReportProps {
     statusSlices: Array<{ key: string; count: number }>;
     periodLabel: string;
     ordersTableProps: OrdersTableProps;
-    ordersTableFilters: {
-        status: string[];
-        clientQuery: string;
-        productQuery: string;
+    ordersTableFilters?: {
+        status?: string[];
+        clientQuery?: string;
+        productQuery?: string;
     };
 }
 
@@ -97,24 +97,30 @@ export const PrintableReport = React.forwardRef<HTMLDivElement, PrintableReportP
                     <section style={{ marginBottom: 24 }}>
                         <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                             <tbody>
-                                <tr>
-                                    <td style={cellLabel}>Estados</td>
-                                    <td style={cellValue}>
-                                        {ordersTableFilters.status.join(', ') || 'Todos'}
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style={cellLabel}>Cliente</td>
-                                    <td style={cellValue}>
-                                        {ordersTableFilters.clientQuery || 'Todos'}
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style={cellLabel}>Producto</td>
-                                    <td style={cellValue}>
-                                        {ordersTableFilters.productQuery || 'Todos'}
-                                    </td>
-                                </tr>
+                                {ordersTableFilters?.status && (
+                                    <tr>
+                                        <td style={cellLabel}>Estados</td>
+                                        <td style={cellValue}>
+                                            {ordersTableFilters.status.join(', ') || 'Todos'}
+                                        </td>
+                                    </tr>
+                                )}
+                                {ordersTableFilters?.clientQuery && (
+                                    <tr>
+                                        <td style={cellLabel}>Cliente</td>
+                                        <td style={cellValue}>
+                                            {ordersTableFilters.clientQuery || 'Todos'}
+                                        </td>
+                                    </tr>
+                                )}
+                                {ordersTableFilters?.productQuery && (
+                                    <tr>
+                                        <td style={cellLabel}>Producto</td>
+                                        <td style={cellValue}>
+                                            {ordersTableFilters.productQuery || 'Todos'}
+                                        </td>
+                                    </tr>
+                                )}
                             </tbody>
                         </table>
                     </section>


### PR DESCRIPTION
Modifiqué las props del componente PrintableReport.tsx para que sea opcional la propiedad ordersTableFilters y también sus valores status, clientQuery y productQuery, la razón de esto es para que no afecte a otros componentes que si los utilice y poder mantener la escalabilidad del componente, en el componente AdminReport.tsx ya no se pasa como prop ordersTableFilters cuando se renderiza el componente PrintableReports haciendo que no se visualizen las 3 celdas de estado, cliente y producto


Antes:
<img width="803" height="330" alt="image" src="https://github.com/user-attachments/assets/34f3a2e9-4463-4bcd-8cd7-3e5856e37b42" />


Despues:
<img width="796" height="246" alt="image" src="https://github.com/user-attachments/assets/0884a916-ab6b-4ec2-b6d7-c0b5eb1d4c25" />

