### PR TITLE
1211 corregir textos y duplicado de título en la edición de categorías

### DIFF
--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
@@ -68,26 +68,27 @@
 }
 
 .cancelBtn {
-    font-family: var(--font-ui);
-    font-size: 0.9rem;
-    font-weight: 600;
-    background: var(--color-bg-secondary);
-    color: var(--color-text-secondary);
-    border: 1px solid var(--color-border, #e2e8f0);
+    padding: 8px 18px;
+    border: 1px solid var(--color-border);
     border-radius: 6px;
-    padding: 8px 16px;
+    background: var(--color-bg-secondary);
+    color: var(--color-text-muted, #64748b);
+    font-size: 0.9rem;
+    font-weight: 500;
     cursor: pointer;
     transition: background 0.15s;
 }
 
 .cancelBtn:hover:not(:disabled) {
-    background: var(--color-bg-tertiary, #f1f5f9);
+    background: var(--color-bg-tertiary);
 }
 
 .cancelBtn:disabled {
-    opacity: 0.6;
+    opacity: 0.5;
     cursor: not-allowed;
 }
+
+
 
 .submitBtn {
     font-family: var(--font-ui);
@@ -253,7 +254,7 @@
     gap: 8px;
     font-size: 0.95rem;
     font-weight: 600;
-    color: var(--color-text, #1e293b);
+    color: var(--color-text-primary, #1e293b);
     margin-bottom: 20px;
     padding-bottom: 12px;
     border-bottom: 1px solid var(--color-border, #e2e8f0);
@@ -357,10 +358,11 @@
 }
 
 .fieldHint {
-    font-family: var(--font-ui);
-    font-size: var(--text-xs, 12px);
-    color: var(--color-text-tertiary, #9ca3af);
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--color-text-tertiary);
     margin-top: 4px;
+    line-height: 1.4;
 }
 
 .checkboxLabel {

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
@@ -34,7 +34,7 @@
 .pageTitle {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--color-text, #1e293b);
+    color: var(--color-text-primary, #1e293b);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -127,7 +127,8 @@
 /* ── Sticky sidebar ──────────────────────────────────────────────────────── */
 .sidebar {
     position: sticky;
-    top: 135px; /* Ajusta este valor según el alto real del navbar/header */
+    top: 135px;
+    /* Ajusta este valor según el alto real del navbar/header */
     align-self: flex-start;
     width: 188px;
     flex-shrink: 0;

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useMemo } from 'react';
-import { FileText, Image, ArrowLeft, AlertCircle, Upload, X } from 'lucide-react';
+import { ArrowLeft, AlertCircle, Upload, X } from 'lucide-react';
 import { useBlocker } from 'react-router-dom';
 import { useCategoryForm } from '../../../hooks/useCategoryFormPage';
 import { ModalConfirm } from '../../../components/ui/ModalConfirm/ModalConfirm';
@@ -17,8 +17,8 @@ interface Props {
 
 // ── Section definitions ────────────────────────────────────────────────────
 const SECTIONS = [
-    { id: 'basico', label: 'Básico', Icon: FileText },
-    { id: 'imagenes', label: 'Imágenes', Icon: Image },
+    { id: 'basico', label: 'Básico', Icon: 'bi bi-file-earmark-text' },
+    { id: 'imagenes', label: 'Imágenes', Icon: 'bi bi-image' },
 ] as const;
 
 type SectionId = typeof SECTIONS[number]['id'];
@@ -54,6 +54,8 @@ export function AdminCategoryFormPage({
         () => categories.filter(c => c.id !== categoryId),
         [categories, categoryId]
     );
+
+    const isActive = (sectionId: SectionId) => activeSection === sectionId;
 
     // Optimized isDirty comparison
     const shallowCompareRelevantFields = React.useCallback(
@@ -195,11 +197,11 @@ export function AdminCategoryFormPage({
                                             }`}
                                         onClick={() => scrollToSection(section.id)}
                                     >
-                                        <section.Icon
-                                            size={15}
-                                            className={styles.sidebarIcon}
-                                            strokeWidth={activeSection === section.id ? 2.5 : 1.8}
-                                        />
+                                        <i className={section.Icon}
+                                            style={{
+                                                color: isActive(section.id) ? 'white' : 'var(--color-primary)',
+                                                fontSize: '1.1rem'
+                                            }} />
                                         <span className={styles.sidebarLabel}>{section.label}</span>
                                         {hasError && (
                                             <AlertCircle
@@ -220,7 +222,7 @@ export function AdminCategoryFormPage({
                             className={styles.sidebarProgressBar}
                             style={{
                                 height: `${((SECTIONS.findIndex(s => s.id === activeSection) + 1) /
-                                        SECTIONS.length) *
+                                    SECTIONS.length) *
                                     100
                                     }%`,
                             }}
@@ -238,7 +240,7 @@ export function AdminCategoryFormPage({
                     {/* ── Básico ─────────────────────────────────────────────── */}
                     <section id="basico" ref={setSectionRef('basico')} className={styles.section}>
                         <h2 className={styles.sectionTitle}>
-                            <FileText size={17} strokeWidth={1.8} /> Información básica
+                            Información Básica
                         </h2>
                         <CategoryTabBasico
                             form={formProps.form}
@@ -255,11 +257,12 @@ export function AdminCategoryFormPage({
                         className={styles.section}
                     >
                         <h2 className={styles.sectionTitle}>
-                            <Image size={17} strokeWidth={1.8} /> Imagen
+                            Imagen
                         </h2>
                         <fieldset className={styles.fieldset}>
-                            <legend className={styles.legend}>Imagen de la categoría *</legend>
-
+                            <p className={styles.fieldHint}>
+                                Carga imágenes del producto. Las imágenes serán mostradas en el orden que se carguen.
+                            </p>
                             {(formProps.fieldErrors.image || formProps.imgError) && (
                                 <div className={styles.imgError}>
                                     {formProps.fieldErrors.image || formProps.imgError}

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
@@ -191,9 +191,8 @@ export function AdminCategoryFormPage({
                                 <li key={section.id}>
                                     <button
                                         type="button"
-                                        className={`${styles.sidebarItem} ${
-                                            activeSection === section.id ? styles.sidebarItemActive : ''
-                                        }`}
+                                        className={`${styles.sidebarItem} ${activeSection === section.id ? styles.sidebarItemActive : ''
+                                            }`}
                                         onClick={() => scrollToSection(section.id)}
                                     >
                                         <section.Icon
@@ -220,11 +219,10 @@ export function AdminCategoryFormPage({
                         <div
                             className={styles.sidebarProgressBar}
                             style={{
-                                height: `${
-                                    ((SECTIONS.findIndex(s => s.id === activeSection) + 1) /
+                                height: `${((SECTIONS.findIndex(s => s.id === activeSection) + 1) /
                                         SECTIONS.length) *
                                     100
-                                }%`,
+                                    }%`,
                             }}
                         />
                     </div>

--- a/frontend/src/features/admin/categories/tabs/CategoryTabBasico.tsx
+++ b/frontend/src/features/admin/categories/tabs/CategoryTabBasico.tsx
@@ -39,7 +39,6 @@ export function CategoryTabBasico({
         <>
             {/* ── Información básica ── */}
             <fieldset className={styles.fieldset}>
-                <legend className={styles.legend}>Información básica</legend>
 
                 <div className={styles.row}>
                     <div className={styles.field}>
@@ -47,9 +46,8 @@ export function CategoryTabBasico({
                             Nombre *
                         </label>
                         <input
-                            className={`${styles.input} ${
-                                touched.name && errors.name ? styles.inputError : ''
-                            }`}
+                            className={`${styles.input} ${touched.name && errors.name ? styles.inputError : ''
+                                }`}
                             id="category-name"
                             value={form.name}
                             onChange={e => handleNameChange(e.target.value)}
@@ -67,9 +65,8 @@ export function CategoryTabBasico({
                             Slug (URL amigable)
                         </label>
                         <input
-                            className={`${styles.input} ${
-                                touched.slug && errors.slug ? styles.inputError : ''
-                            }`}
+                            className={`${styles.input} ${touched.slug && errors.slug ? styles.inputError : ''
+                                }`}
                             id="category-slug"
                             value={form.slug}
                             onChange={e => {

--- a/frontend/src/features/admin/products/AdminProductFormPage.module.css
+++ b/frontend/src/features/admin/products/AdminProductFormPage.module.css
@@ -1105,7 +1105,7 @@
 .pageTitle {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--color-text, #1e293b);
+    color: var(--color-text-primary, #1e293b);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1326,7 +1326,7 @@
     gap: 8px;
     font-size: 0.95rem;
     font-weight: 600;
-    color: var(--color-text, #ffffff);
+    color: var(--color-text-primary, #ffffff);
     margin-bottom: 20px;
     padding-bottom: 12px;
     border-bottom: 1px solid var(--color-border, #e2e8f0);


### PR DESCRIPTION
Corregí los estilos de los titulos de las secciones en el AdminCategoryFormPage.tsx, lo que ocurría era que tenia la propiedad color: var(--text-color) lo que causaba que al estar en dark mode no se visualice, por lo que cambié el valor a var(--text-color-primary) logrando que se visualice claramente en ambos modos.
Este error también ocurría en AdminProductFormPage.tsx por lo que también hice lo mismo en el estilo de esa clase del componente.
Para mantener la coherencia entre las vistas reemplacé iconos y estilos de AdminCategoryFormPage.tsx por los que se utilizan en en AdminProductFormPage.tsx logrando una mejor coherencia visual entre ambas vistas.
La duplicación de titulos que ocurría entre titulos de sección y titulo del tab de la sección ya no existen por lo que se visualiza correctamente y resulta menos confuso el resultado.

Resultado
<img width="1332" height="801" alt="image" src="https://github.com/user-attachments/assets/263a2a1b-ec4a-441e-a39b-6009df32ffde" />
