### PR TITLE
1299 detalle de producto home no tachar precio bogo y permitir selección correcta de variantes

### DIFF
--- a/frontend/src/components/ui/CartPriceDisplay/CartPriceDisplay.tsx
+++ b/frontend/src/components/ui/CartPriceDisplay/CartPriceDisplay.tsx
@@ -40,18 +40,25 @@ export const CartPriceDisplay: React.FC<CartPriceDisplayProps> = ({
     const finalPrice = finalUnitPrice * quantity;
     const discountAmount = discount.discountAmount * quantity;
 
+    // Determinar si mostrar precio original tachado
+    // Solo mostrar tachado para descuentos "percentage" o "fixed", NO para "bogo"
+    const shouldShowStrikethrough =
+        discount.promotionType === 'percentage' || discount.promotionType === 'fixed';
+
     return (
         <div className={styles.priceContainer}>
-            {/* Precio original tachado */}
-            <span className={styles.originalPrice}>
-                {formatPrice(originalPrice * quantity)}
-                {/* Badge de descuento */}
-                {showDiscountBadge && (
-                    <span className={styles.discountBadge}>
-                        -{discount.discountPercentage.toFixed(0)}%
-                    </span>
-                )}
-            </span>
+            {/* Precio original tachado (solo para descuentos percentage o fixed) */}
+            {shouldShowStrikethrough && (
+                <span className={styles.originalPrice}>
+                    {formatPrice(originalPrice * quantity)}
+                    {/* Badge de descuento */}
+                    {showDiscountBadge && (
+                        <span className={styles.discountBadge}>
+                            -{discount.discountPercentage.toFixed(0)}%
+                        </span>
+                    )}
+                </span>
+            )}
 
             {/* Precio con descuento */}
             <span className={styles.discountedPrice}>

--- a/frontend/src/components/ui/ProductPrice/ProductPrice.tsx
+++ b/frontend/src/components/ui/ProductPrice/ProductPrice.tsx
@@ -25,11 +25,18 @@ export const ProductPrice: React.FC<ProductPriceProps> = ({
   size = "md",
   discountPercentage,
 }) => {
-  // Si hay descuento, mostrar precio original tachado + precio con descuento
+  // Determinar si mostrar precio original tachado
+  // Solo mostrar tachado para descuentos "percentage" o "fixed", NO para "bogo"
+  const shouldShowStrikethrough = discount &&
+    (discount.promotionType === 'percentage' || discount.promotionType === 'fixed');
+
+  // Si hay descuento, mostrar precio original (tachado si aplica) + precio con descuento
   if (discount) {
     return (
       <div className={`${styles.priceBlock} ${styles[size]} ${className}`.trim()}>
-        <span className={styles.originalPrice}>{formatPrice(price)}</span>
+        {shouldShowStrikethrough && (
+          <span className={styles.originalPrice}>{formatPrice(price)}</span>
+        )}
         <div className={styles.discountedContainer}>
           <span className={styles.currentPrice}>{formatPrice(discount.finalPrice)}</span>
           {discountPercentage && (

--- a/frontend/src/pages/ProductDetail/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetail/ProductDetailPage.tsx
@@ -134,7 +134,7 @@ export function ProductDetailPage() {
   // 🟢 FIX: Autoseleccionar la variante más barata disponible para coincidir con el precio del catálogo
   useEffect(() => {
     if (product && product.skus && product.skus.length > 0 && Object.keys(selectedVariants).length === 0) {
-      
+
       // Ordenamos las variantes por precio de menor a mayor
       const sortedSkus = [...product.skus].sort((a, b) => {
         const priceA = a.price ?? product.price;
@@ -242,49 +242,55 @@ export function ProductDetailPage() {
   }, [matchingSku, selectedVariants]);
 
   function isOptionAvailable(attr: string, value: string) {
-    return product?.skus?.some(sku => {
-      const matchesOther = Object.entries(selectedVariants).every(([k, v]) => {
-        if (k === attr) return true;
-        return getAttr(sku, k) === v;
-      });
+    if (!product?.skus) return false;
 
-      return matchesOther && getAttr(sku, attr) === value;
+    const isColorGroup = attr.toLowerCase().includes('color') || normalizeColor(value) !== null;
+    const otherSelectedAttrs = Object.entries(selectedVariants).filter(([k]) => k !== attr);
+
+    return product.skus.some(sku => {
+      if (getAttr(sku, attr) !== value) return false;
+      if (isColorGroup) return true;
+      return otherSelectedAttrs.every(([k, v]) => getAttr(sku, k) === v);
     });
   }
 
-  function findCompatibleVariants(newSelection: Record<string, string>): Record<string, string> {
+  function findCompatibleVariants(newSelection: Record<string, string>, changedAttr?: string): Record<string, string> {
     if (!product?.skus || Object.keys(variantMap).length === 0) {
       return newSelection;
     }
 
     const result = { ...newSelection };
-    const compatibleSkus = product.skus.filter(sku => {
-      return Object.entries(result).every(([k, v]) => {
-        return getAttr(sku, k) === v;
-      });
-    });
 
-    if (compatibleSkus.length === 0) {
+    const hasExactMatch = () => product.skus?.some(sku => {
+      return Object.entries(result).every(([k, v]) => getAttr(sku, k) === v);
+    }) ?? false;
+
+    if (hasExactMatch()) {
       return result;
     }
 
-    for (const attr of Object.keys(variantMap)) {
-      if (!result[attr]) {
-        const possibleValues = new Set<string>();
-        compatibleSkus.forEach(sku => {
-          const value = getAttr(sku, attr);
-          if (value) {
-            possibleValues.add(value);
-          }
+    let removedSomething = true;
+    while (removedSomething) {
+      removedSomething = false;
+
+      for (const key of Object.keys(result)) {
+        if (key === changedAttr) continue;
+
+        const reducedSelection = { ...result };
+        delete reducedSelection[key];
+
+        const hasCompatibleSku = product.skus.some(sku => {
+          return Object.entries(reducedSelection).every(([k, v]) => getAttr(sku, k) === v);
         });
 
-        const originalOrderedValues = variantMap[attr] || [];
-        for (const value of originalOrderedValues) {
-          if (possibleValues.has(value)) {
-            result[attr] = value;
-            break;
-          }
+        if (hasCompatibleSku) {
+          delete result[key];
+          removedSomething = true;
         }
+      }
+
+      if (hasExactMatch()) {
+        break;
       }
     }
 
@@ -502,7 +508,7 @@ export function ProductDetailPage() {
                           onClick={() =>
                             setSelectedVariants(prev => {
                               const newSelection = { ...prev, [attr]: val };
-                              return findCompatibleVariants(newSelection);
+                              return findCompatibleVariants(newSelection, attr);
                             })
                           }
                         >
@@ -552,7 +558,7 @@ export function ProductDetailPage() {
                   key={group.id}
                   group={group}
                   selected={selectedVariants[group.id]}
-                  onSelect={(value) => setSelectedVariants(prev => findCompatibleVariants({ ...prev, [group.id]: value }))}
+                  onSelect={(value) => setSelectedVariants(prev => findCompatibleVariants({ ...prev, [group.id]: value }, group.id))}
                 />
               ))}
             </div>


### PR DESCRIPTION
Se arregló el tachado en el precio para la promoción BOGO, ahora solo se tacha el precio de las promociones porcentaje y monto fijo
Se arregló el bloqueo de selección de variantes en el detalle del producto en el home, ahora si tengo 2 variantes con muchos valores en una sola variante, en la otra variante un unico valor y tengo una unica combinación que contiene las 2 variantes, al seleccionar esa combinación no se me inhabilitan los botones de los demás valores de las variantes

Antes:
<img width="1038" height="531" alt="image" src="https://github.com/user-attachments/assets/a5eaa626-c8ca-4b0e-8797-82de4da7438d" />

Ahora:
<img width="1600" height="819" alt="image" src="https://github.com/user-attachments/assets/5f6c9ed9-349c-4992-85b5-1ba998677c90" />
