### PR TITLE
1340 responsive   corregir responsive de la vista de categorías para evitar superposiciones y ordenar el layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ const SuppliersAdmin = lazy(() => import('./features/admin/suppliers/SuppliersAd
 const SuppliersAdminFormWrapper = lazy(() => import('./features/admin/suppliers/SuppliersAdminFormWrapper').then(m => ({ default: m.SuppliersAdminFormWrapper })));
 const AdminCategories = lazy(() => import('./features/admin/categories/AdminCategories').then(m => ({ default: m.AdminCategories })));
 const AdminCategoryFormPageWrapper = lazy(() => import('./features/admin/categories/AdminCategoryFormPageWrapper').then(m => ({ default: m.AdminCategoryFormPageWrapper })));
+const AdminCategoryDetailPageWrapper = lazy(() => import('./features/admin/categories/AdminCategoryDetailPageWrapper').then(m => ({ default: m.AdminCategoryDetailPageWrapper })));
 const AdminCategoryProducts = lazy(() => import('./features/admin/categories/AdminCategoryProducts').then(m => ({ default: m.AdminCategoryProducts })));
 const AdminPromotions = lazy(() => import('./features/admin/promotions').then(m => ({ default: m.AdminPromotions })));
 const AdminCollections = lazy(() => import('./features/admin/collections').then(m => ({ default: m.AdminCollections })));
@@ -226,6 +227,15 @@ const router = createBrowserRouter([
           <AdminRoute requiredPermission="categories.view">
             <Suspense fallback={<AdminLoadingFallback />}>
               <AdminCategoryProducts />
+            </Suspense>
+          </AdminRoute>
+        )
+      }, {
+        path: "/admin/categorias/:categoryId/detalle",
+        element: (
+          <AdminRoute requiredPermission="categories.view">
+            <Suspense fallback={<AdminLoadingFallback />}>
+              <AdminCategoryDetailPageWrapper />
             </Suspense>
           </AdminRoute>
         )

--- a/frontend/src/components/ui/ExportButtons.module.css
+++ b/frontend/src/components/ui/ExportButtons.module.css
@@ -27,7 +27,8 @@
   border-right: 1px solid var(--color-border);
   color: var(--color-text-secondary);
   font-family: var(--font-ui);
-  font-size: 0.8125rem; /* 13px */
+  font-size: 0.8125rem;
+  /* 13px */
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
@@ -93,8 +94,13 @@
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ── Label ── */
@@ -130,5 +136,9 @@
     font-size: 0.75rem;
     padding: 8px 10px;
     gap: 4px;
+  }
+
+  .exportGroup {
+    flex: 1;
   }
 }

--- a/frontend/src/features/admin/categories/AdminCategories.module.css
+++ b/frontend/src/features/admin/categories/AdminCategories.module.css
@@ -948,8 +948,14 @@
   min-width: 120px;
 }
 
+.filtersRowItemSelect {
+  flex: 1 1 140px;
+  min-width: 140px;
+  max-width: 200px;
+}
+
 .filtersRowItem:focus,
-.filtersRowItem:hover{
+.filtersRowItem:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -993,6 +999,14 @@
 @media (max-width: 480px) {
   .filters {
     gap: 6px;
+  }
+
+  .filtersRowItem {
+    flex: 1;
+  }
+
+  .filtersRowItemSelect {
+    max-width: none;
   }
 }
 
@@ -1279,11 +1293,17 @@
   border: 1px solid var(--color-border);
 }
 
-.exportBtnContainer{
+.exportBtnContainer {
   display: flex;
   gap: 8px;
   align-items: center;
   flex-wrap: wrap;
+}
+
+@media (max-width: 480px) {
+  .exportBtnContainer {
+    flex: 1;
+  }
 }
 
 .sortContainer {
@@ -1291,6 +1311,12 @@
   gap: 12px;
   align-items: center;
   flex-wrap: wrap;
+}
+
+@media (max-width: 480px) {
+  .sortContainer {
+    flex: 1;
+  }
 }
 
 .sortControls {
@@ -1301,6 +1327,13 @@
   background: var(--color-bg-card);
   border-radius: 8px;
   border: 1px solid var(--color-border);
+}
+
+@media (max-width: 480px) {
+  .sortControls {
+    justify-content: space-around;
+    flex: 1;
+  }
 }
 
 .sortLabel {
@@ -1324,7 +1357,7 @@
 }
 
 .sortSelect:focus,
-.sortSelect:hover{
+.sortSelect:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);
@@ -1344,7 +1377,7 @@
 }
 
 .sortButton:focus,
-.sortButton:hover{
+.sortButton:hover {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(118, 146, 130, 0.1);

--- a/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
@@ -4,6 +4,7 @@
     flex-direction: column;
     min-height: 100vh;
     padding-bottom: 88px;
+    border-radius: 10px;
     background: var(--color-bg-primary, #fff);
 }
 
@@ -130,7 +131,7 @@
 
 .statWarn {
     border-color: #fbbf24;
-    background: #fffbeb;
+    background: var(--color-bg-warning);
 }
 
 .statValue {

--- a/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
@@ -1,0 +1,219 @@
+/* AdminCategoryDetailPage.module.css */
+.page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    padding-bottom: 88px;
+    background: var(--color-bg-primary, #fff);
+}
+
+.header {
+    padding: 12px 16px;
+}
+
+.backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 0;
+    cursor: pointer;
+}
+
+.summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px 16px;
+}
+
+.avatar {
+    width: 56px;
+    height: 56px;
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--color-bg-tertiary, #f1f5f9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.title {
+    margin: 0;
+    font-size: 17px;
+    font-weight: 700;
+}
+
+.slug {
+    font-size: 12px;
+    color: var(--color-text-tertiary);
+}
+
+.chip {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 999px;
+}
+
+.chipVisible {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.chipHidden {
+    background: #f1f5f9;
+    color: #64748b;
+}
+
+.tabs {
+    display: flex;
+    border-bottom: 1px solid var(--color-border, #e5e2dd);
+    padding: 0 16px;
+    gap: 4px;
+}
+
+.tabBtn {
+    flex: 1;
+    padding: 10px 0;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+}
+
+.tabActive {
+    color: var(--color-primary, #769282);
+    border-bottom-color: var(--color-primary, #769282);
+}
+
+.content {
+    padding: 16px;
+    flex: 1;
+}
+
+.statsRow {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+
+.statCard {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--color-border, #e5e2dd);
+    border-radius: 10px;
+    padding: 10px 12px;
+    flex: 1;
+    min-width: 120px;
+}
+
+.statWarn {
+    border-color: #fbbf24;
+    background: #fffbeb;
+}
+
+.statValue {
+    display: block;
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.statLabel {
+    display: block;
+    font-size: 11px;
+    color: var(--color-text-tertiary);
+}
+
+.section {
+    margin-bottom: 16px;
+}
+
+.sectionTitle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    margin: 0 0 8px;
+}
+
+.description {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+}
+
+.emptyDescription {
+    font-size: 13px;
+    color: var(--color-text-tertiary);
+    font-style: italic;
+}
+
+.imagePreview img {
+    width: 100%;
+    border-radius: 12px;
+    object-fit: cover;
+    max-height: 260px;
+}
+
+.footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px;
+    background: #fff;
+    border-top: 1px solid var(--color-border, #e5e2dd);
+}
+
+.btnEdit,
+.btnToggle,
+.btnDelete {
+    flex: 1;
+    border-radius: 8px;
+    padding: 12px 0;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.btnEdit {
+    background: var(--color-primary, #769282);
+    color: #fff;
+    border: none;
+}
+
+.btnToggle {
+    background: #fff;
+    border: 1px solid #cbd5e1;
+    color: #334155;
+}
+
+.btnDelete {
+    background: #ef4444;
+    color: #fff;
+    border: none;
+}

--- a/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryDetailPage.module.css
@@ -185,7 +185,7 @@
     display: flex;
     gap: 8px;
     padding: 12px 16px;
-    background: #fff;
+    background: var(--color-bg-primary, #fff);
     border-top: 1px solid var(--color-border, #e5e2dd);
 }
 

--- a/frontend/src/features/admin/categories/AdminCategoryDetailPage.tsx
+++ b/frontend/src/features/admin/categories/AdminCategoryDetailPage.tsx
@@ -1,0 +1,280 @@
+// pages/AdminCategoryDetailPage.tsx
+import { useEffect, useMemo, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+    ArrowLeft, Eye, EyeOff, Image as ImageIcon, Tag, Hash, Layers, AlertTriangle,
+} from 'lucide-react';
+import { useAdminCategories } from '../../../context/AdminCategoriesContext';
+import { useAdminAuth } from '../../../context/AdminAuthContext';
+import { useNotification } from '../../../context';
+import { LoadingSpinner } from '../../../components/ui/LoadingSpinner';
+import { EmptyState } from '../../../components/ui/EmptyState';
+import { ModalConfirm } from '../../../components/ui/ModalConfirm/ModalConfirm';
+import styles from './AdminCategoryDetailPage.module.css';
+
+const SECTIONS = [
+    { id: 'info', label: 'Información' },
+    { id: 'imagen', label: 'Imagen' },
+] as const;
+type SectionId = typeof SECTIONS[number]['id'];
+
+interface Props {
+    categoryParam: string;
+    onBack: () => void;
+}
+
+export function AdminCategoryDetailPage({ categoryParam, onBack }: Props) {
+    const navigate = useNavigate();
+    const pageRef = useRef<HTMLDivElement>(null);
+    const { categories, isLoading, refreshCategories, updateCategory, deleteCategory } = useAdminCategories();
+    const { can } = useAdminAuth();
+    const { showNotification } = useNotification();
+
+    const canEdit = can('categories.edit');
+    const canDelete = can('categories.delete');
+
+    const [activeSection, setActiveSection] = useState<SectionId>('info');
+    const [imgError, setImgError] = useState(false);
+    const [deleteConfirm, setDeleteConfirm] = useState(false);
+    const [toggleConfirm, setToggleConfirm] = useState<{ newVisible: boolean } | null>(null);
+    const [actionLoading, setActionLoading] = useState(false);
+
+    const category = useMemo(
+        () => categories.find(
+            (c) => c.id === categoryParam || c.slug?.toLowerCase() === categoryParam.toLowerCase()
+        ),
+        [categories, categoryParam]
+    );
+
+    // Si todavía no cargó la lista (entrada directa por URL), pedila
+    useEffect(() => {
+        if (!category) {
+            refreshCategories({ page: 1, limit: 50 });
+        }
+    }, [category, refreshCategories]);
+
+    useEffect(() => {
+        if (!category) return; // esperá a que el contenido real esté montado
+
+        // 1) scroll del documento
+        window.scrollTo(0, 0);
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0;
+
+        // 2) por si el que scrollea es un contenedor interno del admin layout
+        let el = pageRef.current?.parentElement ?? null;
+        while (el) {
+            const style = window.getComputedStyle(el);
+            if (/(auto|scroll)/.test(style.overflowY) && el.scrollHeight > el.clientHeight) {
+                el.scrollTop = 0;
+            }
+            el = el.parentElement;
+        }
+    }, [categoryParam, category?.id, category]);
+
+    const displayName = category?.name?.trim() || category?.slug || '';
+    const productCount = category?.itemCount;
+
+    const handleEdit = () => {
+        if (category) navigate(`/admin/categorias/${category.id}/editar`);
+    };
+
+    const confirmDelete = async () => {
+        if (!category) return;
+        setActionLoading(true);
+        try {
+            await deleteCategory(category.id);
+            showNotification('success', 'Categoría eliminada correctamente');
+            navigate('/admin/categorias');
+        } catch (err: unknown) {
+            showNotification('error', err instanceof Error ? err.message : 'Error al eliminar la categoría');
+        } finally {
+            setActionLoading(false);
+            setDeleteConfirm(false);
+        }
+    };
+
+    const confirmToggle = async () => {
+        if (!category || !toggleConfirm) return;
+        setActionLoading(true);
+        try {
+            await updateCategory(category.id, { isVisible: toggleConfirm.newVisible });
+            showNotification('success', toggleConfirm.newVisible ? 'Categoría visible' : 'Categoría oculta');
+            await refreshCategories({ page: 1, limit: 50 });
+        } catch (err: unknown) {
+            showNotification('error', err instanceof Error ? err.message : 'Error al cambiar visibilidad');
+        } finally {
+            setActionLoading(false);
+            setToggleConfirm(null);
+        }
+    };
+
+    if (isLoading && !category) {
+        return <LoadingSpinner message="Cargando categoría..." size="lg" />;
+    }
+
+    if (!category) {
+        return (
+            <EmptyState
+                icon={<AlertTriangle size={48} color="#ef4444" />}
+                title="Categoría no encontrada"
+                description="Puede que haya sido eliminada o que el enlace sea incorrecto."
+                action={{ label: 'Volver a categorías', onClick: onBack }}
+            />
+        );
+    }
+
+    return (
+        <div className={styles.page} ref={pageRef}>
+            <header className={styles.header}>
+                <button type="button" className={styles.backBtn} onClick={onBack} aria-label="Volver a la lista">
+                    <ArrowLeft size={16} /> Categorías
+                </button>
+            </header>
+
+            {/* ── Resumen (siempre visible arriba) ─────────────────────── */}
+            <div className={styles.summary}>
+                <div className={styles.avatar}>
+                    {category.image && !imgError ? (
+                        <img src={category.image} alt={displayName} onError={() => setImgError(true)} />
+                    ) : (
+                        <ImageIcon size={28} />
+                    )}
+                </div>
+                <div>
+                    <h1 className={styles.title}>{displayName}</h1>
+                    <span className={styles.slug}>{category.slug}</span>
+                </div>
+                <span className={`${styles.chip} ${category.isVisible ? styles.chipVisible : styles.chipHidden}`}>
+                    {category.isVisible ? <><Eye size={13} /> Visible</> : <><EyeOff size={13} /> Oculta</>}
+                </span>
+            </div>
+
+            {/* ── Tabs ──────────────────────────────────────────────────── */}
+            <div className={styles.tabs} role="tablist" aria-label="Secciones de la categoría">
+                {SECTIONS.map((s) => (
+                    <button
+                        key={s.id}
+                        type="button"
+                        id={`tab-${s.id}`}
+                        role="tab"
+                        aria-selected={activeSection === s.id}
+                        aria-controls={`panel-${s.id}`}
+                        tabIndex={activeSection === s.id ? 0 : -1}
+                        className={`${styles.tabBtn} ${activeSection === s.id ? styles.tabActive : ''}`}
+                        onClick={() => setActiveSection(s.id)}
+                    >
+                        {s.label}
+                    </button>
+                ))}
+            </div>
+
+            <div className={styles.content}>
+                {activeSection === 'info' && (
+                    <div id="panel-info" role="tabpanel" aria-labelledby="tab-info">
+                        <div className={styles.statsRow}>
+                            <div className={styles.statCard}>
+                                <Layers size={16} />
+                                <div>
+                                    <span className={styles.statValue}>{productCount ?? '—'}</span>
+                                    <span className={styles.statLabel}>Productos</span>
+                                </div>
+                            </div>
+                            {productCount === 0 && (
+                                <div className={`${styles.statCard} ${styles.statWarn}`}>
+                                    <AlertTriangle size={16} />
+                                    <span className={styles.statLabel}>Sin productos asignados</span>
+                                </div>
+                            )}
+                            <div className={styles.statCard}>
+                                <Hash size={16} />
+                                <div>
+                                    <span className={styles.statValue} style={{ fontSize: 11, fontFamily: 'monospace' }}>
+                                        {category.id.slice(0, 8)}…
+                                    </span>
+                                    <span className={styles.statLabel}>ID</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className={styles.section}>
+                            <h3 className={styles.sectionTitle}><Tag size={14} /> Descripción</h3>
+                            {category.description ? (
+                                <p className={styles.description}>{category.description}</p>
+                            ) : (
+                                <p className={styles.emptyDescription}>Sin descripción</p>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {activeSection === 'imagen' && (
+                    <div className={styles.section} id="panel-imagen" role="tabpanel" aria-labelledby="tab-imagen">
+                        {category.image && !imgError ? (
+                            <div className={styles.imagePreview}>
+                                <img src={category.image} alt={displayName} onError={() => setImgError(true)} />
+                            </div>
+                        ) : (
+                            <p className={styles.emptyDescription}>Esta categoría no tiene imagen cargada.</p>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* ── Acciones: únicas disponibles en mobile ───────────────── */}
+            {(canEdit || canDelete) && (
+                <div className={styles.footer}>
+                    {canEdit && (
+                        <button type="button" className={styles.btnEdit} onClick={handleEdit} disabled={actionLoading}>
+                            Editar
+                        </button>
+                    )}
+                    {canEdit && (
+                        <button
+                            type="button"
+                            className={styles.btnToggle}
+                            disabled={actionLoading}
+                            onClick={() => setToggleConfirm({ newVisible: !category.isVisible })}
+                        >
+                            {category.isVisible ? 'Ocultar' : 'Mostrar'}
+                        </button>
+                    )}
+                    {canDelete && (
+                        <button
+                            type="button"
+                            className={styles.btnDelete}
+                            disabled={actionLoading}
+                            onClick={() => setDeleteConfirm(true)}
+                        >
+                            Eliminar
+                        </button>
+                    )}
+                </div>
+            )}
+
+            <ModalConfirm
+                open={deleteConfirm}
+                title="Eliminar categoría"
+                description="¿Seguro que querés eliminar esta categoría? Esta acción no se puede deshacer."
+                confirmText="Eliminar"
+                cancelText="Cancelar"
+                onConfirm={confirmDelete}
+                onCancel={() => setDeleteConfirm(false)}
+            />
+
+            <ModalConfirm
+                open={!!toggleConfirm}
+                title={toggleConfirm?.newVisible ? 'Mostrar categoría' : 'Ocultar categoría'}
+                description={
+                    toggleConfirm?.newVisible
+                        ? '¿Mostrar esta categoría? Será visible para los usuarios.'
+                        : '¿Ocultar esta categoría? No será visible para los usuarios.'
+                }
+                confirmText={toggleConfirm?.newVisible ? 'Mostrar' : 'Ocultar'}
+                cancelText="Cancelar"
+                onConfirm={confirmToggle}
+                onCancel={() => setToggleConfirm(null)}
+            />
+        </div>
+    );
+}

--- a/frontend/src/features/admin/categories/AdminCategoryDetailPageWrapper.tsx
+++ b/frontend/src/features/admin/categories/AdminCategoryDetailPageWrapper.tsx
@@ -1,0 +1,15 @@
+// pages/AdminCategoryDetailPageWrapper.tsx
+import { useNavigate, useParams } from 'react-router-dom';
+import { AdminCategoryDetailPage } from './AdminCategoryDetailPage';
+
+export function AdminCategoryDetailPageWrapper() {
+    const navigate = useNavigate();
+    const { categoryId } = useParams<{ categoryId: string }>();
+
+    return (
+        <AdminCategoryDetailPage
+            categoryParam={categoryId ?? ''}
+            onBack={() => navigate('/admin/categorias')}
+        />
+    );
+}

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
@@ -569,6 +569,7 @@
 
     /* El content deja de tener su propio scroll: scrollea la página */
     .content {
+        width: 100%;
         height: auto;
         overflow-y: visible;
         padding-bottom: 24px;
@@ -603,5 +604,11 @@
     .mobileFooter .submitBtn {
         flex: 1;
         padding: 12px 0;
+    }
+}
+
+@media (max-width: 1200px) {
+    .imageUploadTrigger span {
+        text-align: center;
     }
 }

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.module.css
@@ -492,3 +492,116 @@
         transform: rotate(360deg);
     }
 }
+
+/* ── Footer de acciones mobile (oculto en desktop) ───────────────────────── */
+.mobileFooter {
+    display: none;
+}
+
+/* ── Responsive: mobile ───────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .page {
+        padding-bottom: 76px;
+        /* deja espacio para el footer fijo */
+    }
+
+    .fieldHint {
+        text-align: center;
+    }
+
+    .imageUploadTrigger span {
+        text-align: center;
+    }
+
+    .pageHeader {
+        padding: 10px 14px;
+    }
+
+    .pageTitle {
+        font-size: 0.95rem;
+    }
+
+    /* Ocultamos las acciones del header: se muestran abajo en .mobileFooter */
+    .pageHeaderActions {
+        display: none;
+    }
+
+    .layout {
+        flex-direction: column;
+        padding: 12px 12px 0;
+        gap: 12px;
+    }
+
+    /* Sidebar → tabs horizontales sticky debajo del header */
+    .sidebar {
+        position: relative;
+        top: 0;
+        /* alto aprox. del pageHeader en mobile; ajustá si hace falta */
+        z-index: 30;
+        width: 100%;
+        flex-direction: row;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        padding: 6px;
+        gap: 6px;
+        scrollbar-width: none;
+    }
+
+    .sidebar::-webkit-scrollbar {
+        display: none;
+    }
+
+    .sidebarList {
+        flex-direction: row;
+        gap: 6px;
+        flex: 1;
+    }
+
+    .sidebarItem {
+        white-space: nowrap;
+        padding: 8px 12px;
+    }
+
+    /* La barra de progreso vertical no aplica en modo horizontal */
+    .sidebarProgress {
+        display: none;
+    }
+
+    /* El content deja de tener su propio scroll: scrollea la página */
+    .content {
+        height: auto;
+        overflow-y: visible;
+        padding-bottom: 24px;
+    }
+
+    .section {
+        padding: 16px;
+        scroll-margin-top: 100px;
+        /* para que el scroll-spy no tape el título bajo los tabs sticky */
+    }
+
+    .row {
+        grid-template-columns: 1fr;
+        /* un campo por fila en mobile */
+    }
+
+    /* Footer fijo con las acciones, visible solo en mobile */
+    .mobileFooter {
+        display: flex;
+        gap: 8px;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 10px 14px;
+        background: var(--color-bg-primary);
+        border-top: 1px solid var(--color-border);
+        z-index: 50;
+    }
+
+    .mobileFooter .cancelBtn,
+    .mobileFooter .submitBtn {
+        flex: 1;
+        padding: 12px 0;
+    }
+}

--- a/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
+++ b/frontend/src/features/admin/categories/AdminCategoryFormPage.tsx
@@ -336,6 +336,26 @@ export function AdminCategoryFormPage({
                 </form>
             </div>
 
+            {/* ── Footer fijo de acciones (solo mobile, ver CSS) ───────────── */}
+            <div className={styles.mobileFooter}>
+                <button
+                    type="button"
+                    className={styles.cancelBtn}
+                    onClick={handleCancel}
+                    disabled={saving}
+                >
+                    Cancelar
+                </button>
+                <button
+                    type="button"
+                    className={styles.submitBtn}
+                    disabled={saving}
+                    onClick={() => formRef.current?.requestSubmit()}
+                >
+                    {saving ? 'Guardando...' : isEdit ? 'Guardar cambios' : 'Crear categoría'}
+                </button>
+            </div>
+
             {/* ── Unsaved changes warning (cancel button or SPA navigation) ─── */}
             <ModalConfirm
                 open={blocker.state === 'blocked'}

--- a/frontend/src/features/admin/categories/CategoriesMasterDetailLayout.tsx
+++ b/frontend/src/features/admin/categories/CategoriesMasterDetailLayout.tsx
@@ -39,7 +39,7 @@ export function CategoriesMasterDetailLayout({
         defaultSelectedCategoryId ?? categories[0]?.id
     );
 
-    // controla qué panel se ve en mobile (<=1200px)
+    // controla qué panel se ve en mobile (<=768px)
     const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
 
 
@@ -68,6 +68,7 @@ export function CategoriesMasterDetailLayout({
 
     const handleSelectCategory = useCallback((id: string) => {
         setSelectedCategoryId(id);
+        setMobileView('detail');
     }, []);
 
     const handleBackToList = useCallback(() => {
@@ -106,7 +107,7 @@ export function CategoriesMasterDetailLayout({
                         onToggleVisibility={canEdit ? onToggleVisibility : undefined}
                         canEdit={canEdit}
                         canDelete={canDelete}
-                        onBack={handleBackToList}
+                        onBack={mobileView ? handleBackToList : undefined}
                     />
                 ) : !loading && categories.length > 0 ? (
                     <div className={styles.emptyDetail}>

--- a/frontend/src/features/admin/categories/CategoriesMasterDetailLayout.tsx
+++ b/frontend/src/features/admin/categories/CategoriesMasterDetailLayout.tsx
@@ -39,6 +39,10 @@ export function CategoriesMasterDetailLayout({
         defaultSelectedCategoryId ?? categories[0]?.id
     );
 
+    // controla qué panel se ve en mobile (<=1200px)
+    const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
+
+
     // When the list changes (e.g. after a filter), keep selection valid
     React.useEffect(() => {
         if (loading) return;
@@ -66,22 +70,30 @@ export function CategoriesMasterDetailLayout({
         setSelectedCategoryId(id);
     }, []);
 
+    const handleBackToList = useCallback(() => {
+        setMobileView('list'); // NUEVO
+    }, []);
+
     return (
-        <div className={styles.container}>
+        <div
+            className={`${styles.container} ${mobileView === 'detail' ? styles.showDetail : ''}`}
+        >
             {/* ── Left: scrollable category list ──────────────────────── */}
-            <CategoryListPanel
-                categories={categories}
-                loading={loading}
-                error={error}
-                selectedCategoryId={selectedCategoryId}
-                onSelectCategory={handleSelectCategory}
-                onEdit={canEdit ? onEdit : undefined}
-                onDelete={canDelete ? onDelete : undefined}
-                onToggleVisibility={canEdit ? onToggleVisibility : undefined}
-                canEdit={canEdit}
-                canDelete={canDelete}
-                getProductCount={getProductCount}
-            />
+            <div className={styles.listPane}>
+                <CategoryListPanel
+                    categories={categories}
+                    loading={loading}
+                    error={error}
+                    selectedCategoryId={selectedCategoryId}
+                    onSelectCategory={handleSelectCategory}
+                    onEdit={canEdit ? onEdit : undefined}
+                    onDelete={canDelete ? onDelete : undefined}
+                    onToggleVisibility={canEdit ? onToggleVisibility : undefined}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
+                    getProductCount={getProductCount}
+                />
+            </div>
 
             {/* ── Right: detail panel ──────────────────────────────────── */}
             <div className={styles.detailWrapper}>
@@ -94,6 +106,7 @@ export function CategoriesMasterDetailLayout({
                         onToggleVisibility={canEdit ? onToggleVisibility : undefined}
                         canEdit={canEdit}
                         canDelete={canDelete}
+                        onBack={handleBackToList}
                     />
                 ) : !loading && categories.length > 0 ? (
                     <div className={styles.emptyDetail}>

--- a/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
+++ b/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
@@ -50,6 +50,13 @@
     animation: spin 700ms linear infinite;
 }
 
+.listPane {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
 @keyframes spin {
     to {
         transform: rotate(360deg);
@@ -58,11 +65,31 @@
 
 @media (max-width: 1200px) {
     .container {
+        display: flex;
         flex-direction: column;
         height: auto;
+        min-height: 70vh;
+        overflow: hidden;
     }
 
+    .listPane,
     .detailWrapper {
-        height: 300px;
+        width: 100%;
+        min-height: 70vh;
+        flex: 1 1 auto;
+    }
+
+    /* Por defecto se ve la lista, el detalle queda oculto */
+    .detailWrapper {
+        display: none;
+    }
+
+    /* Cuando el layout está en modo detalle, se invierte */
+    .container.showDetail .listPane {
+        display: none;
+    }
+
+    .container.showDetail .detailWrapper {
+        display: flex;
     }
 }

--- a/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
+++ b/frontend/src/features/admin/categories/Categoriesmasterdetaillayout.module.css
@@ -63,7 +63,7 @@
     }
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 768px) {
     .container {
         display: flex;
         flex-direction: column;

--- a/frontend/src/features/admin/categories/Categorydetailpanel.module.css
+++ b/frontend/src/features/admin/categories/Categorydetailpanel.module.css
@@ -276,3 +276,31 @@
     transform: translateY(0);
 }
 
+.backBtn {
+    display: none;
+    /* oculto en desktop */
+    align-items: center;
+    gap: 6px;
+    background: var(--color-bg-primary);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-family: var(--font-ui);
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    margin-bottom: 12px;
+    transition: background 0.15s, color 0.15s;
+}
+
+.backBtn:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-primary);
+}
+
+@media (max-width: 1200px) {
+    .backBtn {
+        display: inline-flex;
+    }
+}

--- a/frontend/src/features/admin/categories/Categorydetailpanel.module.css
+++ b/frontend/src/features/admin/categories/Categorydetailpanel.module.css
@@ -125,7 +125,7 @@
 }
 
 .statWarn {
-    background: #fffbf5;
+    background: var(--color-bg-warning);
     border-color: #f6d8b8;
 }
 
@@ -206,13 +206,12 @@
     margin-top: auto;
     padding: 16px 24px;
     border-top: 1px solid var(--color-border-light);
-    background: var(--color-bg-secondary);
+    background: var(--color-bg-primary);
 }
 
 .actions {
     display: flex;
     gap: 8px;
-    flex-wrap: wrap;
     justify-content: flex-end;
 }
 
@@ -299,7 +298,7 @@
     color: var(--color-primary);
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 768px) {
     .backBtn {
         display: inline-flex;
     }

--- a/frontend/src/features/admin/categories/Categorydetailpanel.tsx
+++ b/frontend/src/features/admin/categories/Categorydetailpanel.tsx
@@ -8,6 +8,7 @@ import {
     Hash,
     Layers,
     AlertTriangle,
+    ArrowLeft
 } from 'lucide-react';
 import styles from './Categorydetailpanel.module.css';
 
@@ -19,6 +20,7 @@ interface CategoryDetailPanelProps {
     onToggleVisibility?: (id: string, newVisible: boolean) => void;
     canEdit?: boolean;
     canDelete?: boolean;
+    onBack?: () => void;
 }
 
 export function CategoryDetailPanel({
@@ -29,6 +31,7 @@ export function CategoryDetailPanel({
     onToggleVisibility,
     canEdit = true,
     canDelete = true,
+    onBack
 }: CategoryDetailPanelProps) {
     const displayName = category.name?.trim() || category.slug;
     const [imgError, setImgError] = useState(false);
@@ -37,6 +40,16 @@ export function CategoryDetailPanel({
         <div className={styles.panel}>
             {/* ── Header ──────────────────────────────────────────────── */}
             <div className={styles.panelHeader}>
+                {onBack && (
+                    <button
+                        type="button"
+                        className={styles.backBtn}
+                        onClick={onBack}
+                        aria-label="Volver a la lista de categorías"
+                    >
+                        <ArrowLeft size={16} /> Volver
+                    </button>
+                )}
                 <div className={styles.headerContent}>
                     <div className={styles.categoryAvatar}>
                         {category.image && !imgError ? (

--- a/frontend/src/features/admin/categories/Categorylistpanel.module.css
+++ b/frontend/src/features/admin/categories/Categorylistpanel.module.css
@@ -177,9 +177,9 @@
 /* ── Meta line ─────────────────────────────────────────────────── */
 .metaLine {
     display: flex;
+    flex-direction: column;
     align-items: flex-end;
     justify-content: space-between;
-    gap: 5px;
     font-size: 11px;
     color: var(--color-text-tertiary);
     overflow: hidden;
@@ -340,9 +340,5 @@
     .panel {
         inset: 0;
         z-index: 100;
-    }
-
-    .visibilityBadge {
-        display: none;
     }
 }

--- a/frontend/src/features/admin/categories/Categorylistpanel.tsx
+++ b/frontend/src/features/admin/categories/Categorylistpanel.tsx
@@ -41,7 +41,7 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
         ref
     ) => {
         const navigate = useNavigate();
-        const isMobile = useIsMobileViewport(1200);
+        const isMobile = useIsMobileViewport(768);
         const containerRef = useRef<HTMLElement>(null);
 
         useEffect(() => {

--- a/frontend/src/features/admin/categories/Categorylistpanel.tsx
+++ b/frontend/src/features/admin/categories/Categorylistpanel.tsx
@@ -1,4 +1,6 @@
 import React, { useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useIsMobileViewport } from './hooks/useIsMobileViewport';
 import type { Category } from '../../../types';
 import { FolderSearch, AlertCircle, Eye, EyeOff } from 'lucide-react';
 import { EmptyState } from '../../../components/ui/EmptyState';
@@ -38,6 +40,8 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
         },
         ref
     ) => {
+        const navigate = useNavigate();
+        const isMobile = useIsMobileViewport(1200);
         const containerRef = useRef<HTMLElement>(null);
 
         useEffect(() => {
@@ -65,6 +69,14 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
                 e.preventDefault();
                 (e.currentTarget.parentElement?.children[index - 1] as HTMLElement)?.focus();
                 onSelectCategory(categories[index - 1].id);
+            }
+        };
+
+        const handleRowActivate = (id: string, slug: string) => {
+            if (isMobile) {
+                navigate(`/admin/categorias/${slug || id}/detalle`);
+            } else {
+                onSelectCategory(id);
             }
         };
 
@@ -111,11 +123,7 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
         }
 
         return (
-            <aside
-                ref={ref ?? containerRef}
-                className={styles.panel}
-                onScroll={handleScroll}
-            >
+            <aside ref={ref ?? containerRef} className={styles.panel} onScroll={handleScroll}>
                 <div className={styles.listContainer} role="listbox" aria-label="Lista de categorías">
                     {categories.map((cat, index) => {
                         const displayName = cat.name?.trim() || cat.slug;
@@ -131,8 +139,17 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
                                 tabIndex={0}
                                 aria-selected={isSelected}
                                 aria-label={`Seleccionar categoría ${displayName}`}
-                                onClick={() => onSelectCategory(cat.id)}
-                                onKeyDown={(e) => handleKeyDown(e, index)}
+                                onClick={() => handleRowActivate(cat.id, cat.slug)}
+
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        handleRowActivate(cat.id, cat.slug);
+                                    } else {
+                                        handleKeyDown(e, index)
+                                    }
+                                }}
+
                             >
                                 <div className={styles.mainRow}>
                                     {cat.image ? (
@@ -177,7 +194,8 @@ export const CategoryListPanel = React.forwardRef<HTMLElement, CategoryListPanel
                                     </div>
                                 </div>
 
-                                {(canEdit || canDelete) && (
+                                {/* Quick actions: ocultas en mobile, solo viven en la vista dedicada */}
+                                {!isMobile && (canEdit || canDelete) && (
                                     <div className={styles.quickActions}>
                                         {canEdit && onEdit && (
                                             <button

--- a/frontend/src/features/admin/categories/components/CategoriesFilters.tsx
+++ b/frontend/src/features/admin/categories/components/CategoriesFilters.tsx
@@ -76,7 +76,7 @@ export const CategoriesFilters: React.FC<CategoriesFiltersProps> = ({
         />
 
         {/* Filtro de Visibilidad Unificado con Custom Dropdown */}
-        <div style={{ flex: '1 1 140px', minWidth: '140px', maxWidth: '200px' }}>
+        <div className={styles.filtersRowItemSelect}>
           <Dropdown
             id="visibility-filter"
             options={visibilityOptions}

--- a/frontend/src/features/admin/categories/hooks/useIsMobileViewport.ts
+++ b/frontend/src/features/admin/categories/hooks/useIsMobileViewport.ts
@@ -1,0 +1,18 @@
+// hooks/useIsMobileViewport.ts
+import { useEffect, useState } from 'react';
+
+export function useIsMobileViewport(breakpoint = 1200) {
+    const [isMobile, setIsMobile] = useState(
+        () => typeof window !== 'undefined' && window.innerWidth <= breakpoint
+    );
+
+    useEffect(() => {
+        const mql = window.matchMedia(`(max-width: ${breakpoint}px)`);
+        const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+        setIsMobile(mql.matches);
+        mql.addEventListener('change', handler);
+        return () => mql.removeEventListener('change', handler);
+    }, [breakpoint]);
+
+    return isMobile;
+}


### PR DESCRIPTION
En mobile no se muestra el panel del detalle de la categoria, unicamente se muestra la lista de categorias, al clickearse la categoria se redirije a una pantalla dedicada a la información de la categoria donde también se dan las opciones de acciones, solamente en resoluciones menores a 768px se visualiza de esta forma, en resoluciones mayores se visualiza el panel del detalle de la categoria normalmente

<img width="399" height="721" alt="image" src="https://github.com/user-attachments/assets/3fdc7aac-90e3-4bba-a430-f3cecc1039b6" />

<img width="382" height="734" alt="image" src="https://github.com/user-attachments/assets/ea9f9f87-e227-4e88-991c-351f0a536458" />
