### PR TITLE
1341 responsive   ajustar marginpadding y agregar icono de lupa en el input de buscar en responsive de la vista pedidos

### DIFF
--- a/frontend/src/features/admin/orders/AdminOrders.module.css
+++ b/frontend/src/features/admin/orders/AdminOrders.module.css
@@ -762,6 +762,7 @@
   font-size: var(--text-xs);
   color: var(--color-primary-dark);
   letter-spacing: 0.03em;
+  flex: 1;
 }
 
 .mobileCardDate {

--- a/frontend/src/features/admin/orders/AdminOrders.module.css
+++ b/frontend/src/features/admin/orders/AdminOrders.module.css
@@ -371,15 +371,7 @@
   line-height: 1;
 }
 
-@media (max-width: 380px) {
-  .searchIcon {
-    display: none;
-  }
-
-  .searchInput {
-    padding-inline: 0;
-  }
-}
+@media (max-width: 380px) {}
 
 .filterSelect {
   font-family: var(--font-ui);

--- a/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
+++ b/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
@@ -603,4 +603,8 @@
   .itemsTable td {
     padding: 0.4rem 0.25rem;
   }
+
+  .customerFullName {
+    font-size: .8rem;
+  }
 }

--- a/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
+++ b/frontend/src/features/admin/orders/components/OrderDetailContent.module.css
@@ -322,11 +322,15 @@
   font-size: 1rem;
   font-weight: 600;
   color: var(--color-text-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .customerEmailText {
   font-size: 0.85rem;
   color: #64748b;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* ── Productos ── */
@@ -349,6 +353,16 @@
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.02rem;
+}
+
+.tdProduct {
+  word-break: break-word;
+  overflow-wrap: nowrap;
+}
+
+.tdProductName {
+  font-weight: bold;
+  text-transform: capitalize;
 }
 
 .itemsTable td {
@@ -571,6 +585,119 @@
   }
 }
 
+/* ── Productos en mobile: tabla → lista de tarjetas ──
+   A partir de este ancho la tabla clásica (4 columnas) deja de tener
+   espacio para respirar y el texto empieza a solaparse/desbordar.
+   Se reemplaza por un patrón de "tarjetas" (cada <tr> es una tarjeta,
+   cada <td> muestra su etiqueta gracias a data-label), que es el
+   approach recomendado de UX para tablas de datos en viewports chicos. */
+@media (max-width: 640px) {
+  .itemsTable {
+    border: none;
+  }
+
+  .itemsTable thead {
+    /* Se oculta el header de la tabla: las etiquetas pasan a
+       generarse por celda con ::before + data-label */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .itemsTable,
+  .itemsTable tbody,
+  .itemsTable tfoot,
+  .itemsTable tr,
+  .itemsTable td {
+    display: block;
+    width: 100%;
+  }
+
+  .itemsTable tbody tr {
+    margin-bottom: 0.75rem;
+    padding: 0.75rem 0.9rem;
+    background: var(--color-bg-tertiary);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+  }
+
+  .itemsTable tbody tr:last-child {
+    margin-bottom: 0;
+  }
+
+  .itemsTable tbody tr:hover {
+    background: var(--color-bg-tertiary) !important;
+  }
+
+  .itemsTable tbody td {
+    padding: 0.35rem 0;
+    border-bottom: none;
+    background: transparent !important;
+  }
+
+  /* Celda del producto: se mantiene como encabezado de la tarjeta */
+  .tdProduct {
+    padding-bottom: 0.5rem !important;
+    margin-bottom: 0.35rem;
+    border-bottom: 1px dashed var(--color-border) !important;
+    font-weight: 600;
+    text-align: left;
+  }
+
+  /* Cant. / P. unit. / Subtotal: fila "etiqueta — valor" */
+  .itemsTable tbody td[data-label]:not(.tdProduct) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    text-align: right;
+  }
+
+  .itemsTable tbody td[data-label]:not(.tdProduct)::before {
+    content: attr(data-label);
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.03rem;
+    text-align: left;
+    flex-shrink: 0;
+  }
+
+  /* Total: tarjeta destacada, label y valor lado a lado */
+  .itemsTable tfoot tr {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    padding: 0.75rem 0.9rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+  }
+
+  .totalLabel,
+  .totalValue {
+    padding: 0 !important;
+    width: auto;
+  }
+
+  .totalLabel {
+    text-align: left;
+  }
+
+  .totalValue {
+    text-align: right;
+  }
+}
+
 @media (max-width: 480px) {
   .detailContent {
     gap: 1rem;
@@ -596,12 +723,26 @@
   }
 
   .itemsTable {
-    font-size: 0.75rem;
+    font-size: 0.85rem;
   }
 
-  .itemsTable th,
-  .itemsTable td {
-    padding: 0.4rem 0.25rem;
+  .itemsTable tfoot tr {
+    background: var(--color-bg-tertiary);
+    border: none;
+  }
+
+  .itemsTable tfoot tr td {
+    border-bottom: none;
+  }
+
+  .customerCard {
+    padding: 0.75rem;
+  }
+
+  .customerAvatar {
+    width: 44px;
+    height: 44px;
+    font-size: 1rem;
   }
 
   .customerFullName {

--- a/frontend/src/features/admin/orders/components/OrderDetailContent.tsx
+++ b/frontend/src/features/admin/orders/components/OrderDetailContent.tsx
@@ -281,8 +281,8 @@ export const OrderDetailContent = ({ order, onClose }: OrderDetailContentProps) 
           <tbody>
             {order.items.map(item => (
               <tr key={`${item.productId}-${item.productSkuId ?? 'base'}-${item.productName}`}>
-                <td>
-                  <div>{item.productName}</div>
+                <td data-label="Producto" className={styles.tdProduct}>
+                  <div className={styles.tdProductName}>{item.productName}</div>
                   {(item.variant || item.sku) && (
                     <div className={styles.itemVariant}>
                       {item.variant || item.sku}
@@ -290,9 +290,9 @@ export const OrderDetailContent = ({ order, onClose }: OrderDetailContentProps) 
                     </div>
                   )}
                 </td>
-                <td className={styles.tdCenter}>{item.quantity}</td>
-                <td className={styles.tdRight}>{formatPrice(item.unitPrice)}</td>
-                <td className={styles.tdRight}>{formatPrice(item.unitPrice * item.quantity)}</td>
+                <td data-label="Cant." className={styles.tdCenter}>{item.quantity}</td>
+                <td data-label="P. unit." className={styles.tdRight}>{formatPrice(item.unitPrice)}</td>
+                <td data-label="Subtotal" className={styles.tdRight}>{formatPrice(item.unitPrice * item.quantity)}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/features/admin/orders/components/OrderList.tsx
+++ b/frontend/src/features/admin/orders/components/OrderList.tsx
@@ -56,7 +56,7 @@ export function OrderList({ orders, selectedIds, onSelect, onDetail }: OrderList
             onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onDetail(order)}
             style={{
               marginBottom: 16,
-              background: '#fff',
+              background: 'var(--color-bg-primary)',
               animationDelay: `${index * 40}ms`,   // ← añadir index al .map()
             }}
           >


### PR DESCRIPTION
Ahora se visualiza correctamente el input de búsqueda en resoluciones pequeñas

<img width="679" height="756" alt="image" src="https://github.com/user-attachments/assets/3ede4e96-f2d9-4cb8-ace3-799c3b3fd7c4" />

Además aproveché (como era la unica issue que modificaba la vista de Pedidos) a ajustar el detalle de los pedidos ya que habia muchas cosas que se rompían, terminé solucionando los desbordamientos  ajustando la tabla de los productos del detalle de la orden y la información del cliente

<img width="593" height="765" alt="image" src="https://github.com/user-attachments/assets/1af32429-acd9-4644-b5d3-a55d7a6b5543" />
<img width="559" height="773" alt="image" src="https://github.com/user-attachments/assets/b6f641cc-146a-45d7-afec-defe29e399ed" />
