### PR TITLE
Cambios realizados

### DIFF
--- a/frontend/src/features/products/ProductCard/ProductCard.tsx
+++ b/frontend/src/features/products/ProductCard/ProductCard.tsx
@@ -199,7 +199,7 @@ export function ProductCard({ product, variant = 'default' }: ProductCardProps) 
 
         <div className={styles.badges}>
           {isNew && <Badge variant="new">Nuevo</Badge>}
-          {typeof product.stock === 'number' && isLowStock(product.stock, LOW_STOCK_THRESHOLD) && (
+          {variant !== 'featured' && typeof product.stock === 'number' && isLowStock(product.stock, LOW_STOCK_THRESHOLD) && (
             <Badge className={`${styles.badge} ${styles.lowStockBadge}`}>
               <AlertTriangle size={16} style={{ marginRight: 4 }} /> Stock bajo
             </Badge>

--- a/frontend/src/features/products/ProductCard/__tests__/ProductCard.test.tsx
+++ b/frontend/src/features/products/ProductCard/__tests__/ProductCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { ProductCard } from '../ProductCard';
+import type { Product } from '../../../../types';
+
+vi.mock('../../../../components/layout/context/FavoritesContextUtils', () => ({
+  useFavorites: () => ({
+    isFavorite: () => false,
+    toggleFavorite: vi.fn(),
+    syncFavorite: vi.fn(),
+  }),
+}));
+
+const product: Product & { stock?: number } = {
+  id: 'prod-1',
+  name: 'Test Product',
+  slug: 'test-product',
+  description: 'A test product',
+  shortDescription: 'Test product short description',
+  price: 100,
+  images: ['https://example.com/image.jpg'],
+  category: { id: 'cat-1', name: 'Cocina', slug: 'cocina', isVisible: true },
+  tags: [],
+  rating: 4.5,
+  reviewCount: 10,
+  inStock: true,
+  sku: 'TEST-1',
+  stock: 3,
+};
+
+describe('ProductCard', () => {
+  it('does not render low stock badge for featured variant', () => {
+    render(
+      <BrowserRouter>
+        <ProductCard product={product} variant="featured" />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByText(/Stock bajo/i)).not.toBeInTheDocument();
+  });
+
+  it('renders low stock badge for default variant', () => {
+    render(
+      <BrowserRouter>
+        <ProductCard product={product} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText(/Stock bajo/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
ProductCard.tsx

Excluye el badge de Stock bajo cuando el producto se renderiza como variant="featured". ProductCard.test.tsx

Agrega cobertura de prueba para verificar que:
no aparece el badge de stock bajo en la tarjeta destacada. sí aparece en la tarjeta por defecto.