### PR TITLE
Mejorar contraste del botón "Ver Todos" en la colección del Home

### DIFF
--- a/frontend/src/components/CollectionSlider.module.css
+++ b/frontend/src/components/CollectionSlider.module.css
@@ -26,11 +26,9 @@
   border-radius: 16px;
   overflow: hidden;
   margin-bottom: var(--space-5, 20px);
-  background: linear-gradient(
-    135deg,
-    var(--color-primary, #769282) 0%,
-    var(--color-accent, #ddb08c) 100%
-  );
+  background: linear-gradient(135deg,
+      var(--color-primary, #769282) 0%,
+      var(--color-accent, #ddb08c) 100%);
 }
 
 .banner img {
@@ -98,14 +96,32 @@
 }
 
 .viewAll:hover {
-  color: var(--color-primary-dark, #5d7568);
   gap: 8px;
 }
 
 .viewAll:focus-visible {
-  outline: 2px solid var(--color-primary, #769282);
+  outline: 2px solid currentColor;
   outline-offset: 3px;
   border-radius: 4px;
+}
+
+/* ── Sobre fondo verde: texto blanco ── */
+:global(.collection-section--primary) .viewAll {
+  color: var(--color-text-inverse, #ffffff);
+}
+
+:global(.collection-section--primary) .viewAll:hover {
+  color: var(--color-text-inverse, #ffffff);
+  opacity: 0.85;
+}
+
+/* ── Sobre fondo blanco: texto verde oscuro ── */
+:global(.collection-section--inverse) .viewAll {
+  color: var(--color-primary, #769282);
+}
+
+:global(.collection-section--inverse) .viewAll:hover {
+  color: var(--color-primary-dark, #5d7568);
 }
 
 /* ── Wrapper del carrusel: flechas + viewport en línea ── */
@@ -321,6 +337,7 @@
 }
 
 @media (max-width: 767px) {
+
   /* En mobile: el wrapper no necesita flechas */
   .carouselWrapper {
     gap: 0;
@@ -414,7 +431,7 @@
 .carousel {
   position: relative;
   padding: 0 56px;
-  
+
 }
 
 .carouselStatic {


### PR DESCRIPTION
Ahora el botón de ver más cambia de color en base al fondo que esté atras mejorando el contraste
antes
<img width="1597" height="690" alt="image" src="https://github.com/user-attachments/assets/d77cb2c5-cac9-4671-9429-8d091920663e" />

ahora
<img width="1595" height="692" alt="image" src="https://github.com/user-attachments/assets/8d44978b-d591-45bd-ae47-24e58bcc3c19" />
